### PR TITLE
feat: coque em ação, hero carousel, rotas marketing, header fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
 const TransparencyPage = lazy(() => import('./pages/TransparencyPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 const ProjectsPage = lazy(() => import('./pages/ProjectsPage'));
+const AboutPage = lazy(() => import('./pages/AboutPage'));
+const WaysToHelpPage = lazy(() => import('./pages/WaysToHelpPage'));
 
 // Admin sub-routes (lazy)
 const HomeRoute = lazy(() => import('./features/admin/routes/home/HomeRoute').then(m => ({ default: m.HomeRoute })));
@@ -44,6 +46,14 @@ const router = createBrowserRouter([
       {
         path: "nossos-projetos",
         element: <ProjectsPage />,
+      },
+      {
+        path: "quem-somos",
+        element: <AboutPage />,
+      },
+      {
+        path: "como-ajudar",
+        element: <WaysToHelpPage />,
       },
       {
         path: "*",

--- a/src/components/composites/HeaderBar/HeaderBar.tsx
+++ b/src/components/composites/HeaderBar/HeaderBar.tsx
@@ -59,7 +59,7 @@ export const HeaderBar = forwardRef<HTMLElement, HeaderBarProps>(
         )}
         {...props}
       >
-        <div className="mx-auto flex h-[84px] w-full items-center justify-between gap-4 overflow-visible rounded-[999px] bg-[rgba(244,212,194,0.94)] px-3 min-[380px]:px-5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] sm:px-6 lg:gap-8 lg:px-8">
+        <div className="mx-auto flex h-[84px] w-full items-center justify-between gap-4 overflow-visible rounded-[999px] bg-[rgba(244,212,194,0.82)] px-3 min-[380px]:px-5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] backdrop-blur-md sm:px-6 lg:gap-8 lg:px-8">
           {/* Logo */}
           <a href="/" className="flex shrink-0 items-center" aria-label="Coque Connecta">
             <CoqueConnectaWordmark className="h-6 w-[130px] min-[360px]:w-[145px] md:h-8 md:w-auto text-[color:var(--color-tag-bg)] lg:h-9" />

--- a/src/components/composites/HeroPhotoCarousel/HeroPhotoCarousel.tsx
+++ b/src/components/composites/HeroPhotoCarousel/HeroPhotoCarousel.tsx
@@ -37,6 +37,7 @@ export const HeroPhotoCarousel = ({
           src={photo.src}
           alt={photo.alt}
           loading={index === 0 ? 'eager' : 'lazy'}
+          style={{ objectPosition: photo.objectPosition || 'center' }}
           className={cn(
             'absolute inset-0 h-full w-full object-cover',
             // Reduced motion: mantém o ciclo automático (não é o tipo de movimento contínuo

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -1,0 +1,83 @@
+import { cn } from '../../../lib/cn';
+import type { CmsCarouselImage, CmsLanguage, ResolvedYoutubeVideo } from '../../../types/cms';
+import { Block } from '../../ui/Block';
+import { FadeIn } from '../../ui/FadeIn';
+import { VideosSection } from '../VideosSection';
+import { CarouselSection } from '../CarouselSection';
+
+export interface CoqueEmAcaoSectionProps extends React.HTMLAttributes<HTMLElement> {
+  videos?: ResolvedYoutubeVideo[];
+  images?: CmsCarouselImage[];
+  language: CmsLanguage;
+}
+
+// Heading fixo (não-CMS) que une 2 seções de mídia independentes sob 1 narrativa só —
+// mesmo motivo do label de Transparência em TrustSection: é moldura editorial, não
+// conteúdo dinâmico, não justifica um campo i18n próprio no CMS.
+const HEADING: Record<CmsLanguage, { title: string; description: string }> = {
+  pt: {
+    title: 'Coque em ação',
+    description: 'Um retrato em vídeo e fotos do que a comunidade constrói todos os dias.',
+  },
+  en: {
+    title: 'Coque in action',
+    description: 'A look in video and photos at what the community builds every day.',
+  },
+};
+
+export const CoqueEmAcaoSection = ({
+  videos,
+  images,
+  language,
+  className,
+  ...props
+}: CoqueEmAcaoSectionProps) => {
+  const copy = HEADING[language];
+
+  return (
+    <section
+      id="coque-em-acao"
+      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      {...props}
+    >
+      <Block>
+        <FadeIn className="mb-10 flex flex-col gap-4">
+          <h3
+            style={{
+              fontFamily: "'Figtree', sans-serif",
+              fontSize: 'clamp(34px, 4.2vw, 50px)',
+              fontWeight: 700,
+              color: 'var(--color-text-primary)',
+              lineHeight: '1.1',
+              margin: 0,
+              letterSpacing: '-0.8px',
+              maxWidth: '640px',
+              textWrap: 'balance',
+            } as React.CSSProperties}
+          >
+            {copy.title}
+          </h3>
+          <p
+            style={{
+              fontFamily: "'Figtree', sans-serif",
+              fontSize: 'clamp(17px, 2vw, 20px)',
+              lineHeight: '1.5',
+              color: 'var(--color-text-secondary)',
+              maxWidth: '60ch',
+              margin: 0,
+            }}
+          >
+            {copy.description}
+          </p>
+        </FadeIn>
+      </Block>
+
+      <div className="space-y-10 md:space-y-12">
+        <VideosSection videos={videos} className="py-0" />
+        <CarouselSection images={images} className="py-0" />
+      </div>
+    </section>
+  );
+};
+
+CoqueEmAcaoSection.displayName = 'CoqueEmAcaoSection';

--- a/src/components/sections/CoqueEmAcaoSection/index.ts
+++ b/src/components/sections/CoqueEmAcaoSection/index.ts
@@ -1,0 +1,1 @@
+export { CoqueEmAcaoSection, type CoqueEmAcaoSectionProps } from './CoqueEmAcaoSection';

--- a/src/components/sections/HeroSection/HeroSection.tsx
+++ b/src/components/sections/HeroSection/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from 'lucide-react';
 import { cn } from '../../../lib/cn';
-import { ROUTE_HASHES } from '../../../lib/constants';
+import { ROUTES } from '../../../lib/constants';
 import type { ResolvedHeroData } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { Button } from '../../ui/Button';
@@ -72,7 +72,7 @@ export const HeroSection = ({ data, className, ...props }: HeroSectionProps) => 
             <div className="animate-hero-in flex flex-wrap items-center gap-3 pt-2" style={{ animationDelay: '240ms' }}>
               {data.ctaText && (
                 <Button
-                  href={data.ctaHref ?? ROUTE_HASHES.waysToHelp}
+                  href={data.ctaHref ?? ROUTES.waysToHelp}
                   variant="unstyled"
                   className="bg-[color:var(--color-accent-peach)] text-[color:var(--color-tag-bg)] hover:brightness-95 px-6 py-3 text-base sm:text-lg h-12"
                 >
@@ -81,7 +81,7 @@ export const HeroSection = ({ data, className, ...props }: HeroSectionProps) => 
               )}
               {data.secondaryCtaText && (
                 <Button
-                  href={data.secondaryCtaHref ?? ROUTE_HASHES.waysToHelp}
+                  href={data.secondaryCtaHref ?? ROUTES.waysToHelp}
                   variant="secondary"
                   size="lg"
                 >

--- a/src/components/sections/WaysToHelpSection/WaysToHelpCard.tsx
+++ b/src/components/sections/WaysToHelpSection/WaysToHelpCard.tsx
@@ -1,6 +1,7 @@
 import { cn } from '../../../lib/cn';
 import type { ResolvedWaysToHelpCard } from '../../../types/cms';
 import { QuoteIcon, UserAvatarPlaceholderIcon } from '../../icons';
+import { Button } from '../../ui/Button';
 
 export interface WaysToHelpCardProps {
   card: ResolvedWaysToHelpCard;
@@ -83,6 +84,18 @@ export const WaysToHelpCard = ({
               </span>
             ))}
           </div>
+
+          {card.ctaHref && card.ctaLabel && (
+            <Button
+              href={card.ctaHref}
+              variant="unstyled"
+              className="mt-2 h-10 rounded-[50px] px-5 text-sm font-semibold"
+              style={{ backgroundColor: tagBg, color: tagText }}
+              {...(card.ctaHref.startsWith('http') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            >
+              {card.ctaLabel}
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
+++ b/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
@@ -1,0 +1,67 @@
+import { cn } from '../../../lib/cn';
+import type { CmsLanguage, ResolvedWaysToHelpData } from '../../../types/cms';
+import { Block } from '../../ui/Block';
+import { FadeIn } from '../../ui/FadeIn';
+import { Button } from '../../ui/Button';
+import { ROUTES } from '../../../lib/constants';
+
+export interface WaysToHelpTeaserProps extends React.HTMLAttributes<HTMLElement> {
+  data: ResolvedWaysToHelpData;
+  language: CmsLanguage;
+}
+
+const CTA_LABEL: Record<CmsLanguage, string> = {
+  pt: 'Conheça as formas de ajudar →',
+  en: 'See how you can help →',
+};
+
+export const WaysToHelpTeaser = ({ data, language, className, ...props }: WaysToHelpTeaserProps) => {
+  return (
+    <section
+      id="ways-to-help"
+      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      {...props}
+    >
+      <Block>
+        <FadeIn className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4">
+            <h3
+              style={{
+                fontFamily: "'Figtree', sans-serif",
+                fontSize: 'clamp(34px, 4.2vw, 50px)',
+                fontWeight: 700,
+                color: 'var(--color-text-primary)',
+                lineHeight: '1.1',
+                margin: 0,
+                letterSpacing: '-0.8px',
+                maxWidth: '640px',
+                textWrap: 'balance',
+              } as React.CSSProperties}
+            >
+              {data.headline}
+            </h3>
+            {data.subtitle && (
+              <p
+                style={{
+                  fontFamily: "'Figtree', sans-serif",
+                  fontSize: 'clamp(17px, 2vw, 20px)',
+                  lineHeight: '1.5',
+                  color: 'var(--color-text-secondary)',
+                  maxWidth: '60ch',
+                  margin: 0,
+                }}
+              >
+                {data.subtitle}
+              </p>
+            )}
+          </div>
+          <Button href={ROUTES.waysToHelp} variant="primary" size="lg">
+            {CTA_LABEL[language]}
+          </Button>
+        </FadeIn>
+      </Block>
+    </section>
+  );
+};
+
+WaysToHelpTeaser.displayName = 'WaysToHelpTeaser';

--- a/src/components/sections/WaysToHelpTeaser/index.ts
+++ b/src/components/sections/WaysToHelpTeaser/index.ts
@@ -1,0 +1,1 @@
+export { WaysToHelpTeaser, type WaysToHelpTeaserProps } from './WaysToHelpTeaser';

--- a/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
+++ b/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
@@ -1,0 +1,89 @@
+import { cn } from '../../../lib/cn';
+import type { CmsLanguage, ResolvedWhatWeDoData } from '../../../types/cms';
+import { Block } from '../../ui/Block';
+import { FadeIn } from '../../ui/FadeIn';
+import { Button } from '../../ui/Button';
+import { ProjectCard } from '../../composites/ProjectCard';
+import { ProjectGrid } from '../../composites/ProjectGrid';
+import { ROUTES } from '../../../lib/constants';
+import { useCmsProjectsData } from '../../../hooks/useCmsProjectsData';
+
+export interface WhatWeDoSectionProps extends React.HTMLAttributes<HTMLElement> {
+  data: ResolvedWhatWeDoData;
+  language: CmsLanguage;
+}
+
+const SEE_ALL_LABEL: Record<CmsLanguage, string> = {
+  pt: 'Ver todos os projetos →',
+  en: 'See all projects →',
+};
+
+export const WhatWeDoSection = ({
+  data,
+  language,
+  className,
+  ...props
+}: WhatWeDoSectionProps) => {
+  const { data: projects } = useCmsProjectsData(language);
+  const preview = projects.slice(0, 2);
+
+  return (
+    <section
+      id="what-we-do"
+      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      {...props}
+    >
+      <Block>
+        <FadeIn className="mb-10 flex flex-col gap-4">
+          <h3
+            style={{
+              fontFamily: "'Figtree', sans-serif",
+              fontSize: 'clamp(34px, 4.2vw, 50px)',
+              fontWeight: 700,
+              color: 'var(--color-text-primary)',
+              lineHeight: '1.1',
+              margin: 0,
+              letterSpacing: '-0.8px',
+              maxWidth: '640px',
+              textWrap: 'balance',
+            } as React.CSSProperties}
+          >
+            {data.headline || (language === 'pt' ? 'O que Fazemos' : 'What We Do')}
+          </h3>
+          {data.subtitle && (
+            <p
+              style={{
+                fontFamily: "'Figtree', sans-serif",
+                fontSize: 'clamp(17px, 2vw, 20px)',
+                lineHeight: '1.5',
+                color: 'var(--color-text-secondary)',
+                maxWidth: '60ch',
+                margin: 0,
+              }}
+            >
+              {data.subtitle}
+            </p>
+          )}
+        </FadeIn>
+
+        {preview.length > 0 && (
+          <FadeIn delay={80}>
+            <ProjectGrid>
+              {preview.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </ProjectGrid>
+          </FadeIn>
+        )}
+
+        <div className="mt-8">
+          <Button href={ROUTES.whatWeDo} variant="primary">
+            {SEE_ALL_LABEL[language]}
+          </Button>
+        </div>
+      </Block>
+    </section>
+  );
+};
+
+WhatWeDoSection.displayName = 'WhatWeDoSection';

--- a/src/components/sections/WhatWeDoSection/index.ts
+++ b/src/components/sections/WhatWeDoSection/index.ts
@@ -1,0 +1,1 @@
+export { WhatWeDoSection, type WhatWeDoSectionProps } from './WhatWeDoSection';

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -207,7 +207,7 @@ export const mockDataPT: LandingPageData = {
     ],
     quickLinks: [
       { label: "Sobre nós", href: "/#about" },
-      { label: "Como ajudar", href: "/#ways-to-help" },
+      { label: "Como ajudar", href: "/como-ajudar" },
       { label: "Como doar", href: "https://benfeitoria.com/projeto/coqueconnecta" },
       { label: "Transparência", href: "/transparencia" },
     ],
@@ -326,7 +326,7 @@ export const mockDataEN: LandingPageData = {
     ],
     quickLinks: [
       { label: "About us", href: "/#about" },
-      { label: "How to help", href: "/#ways-to-help" },
+      { label: "How to help", href: "/como-ajudar" },
       { label: "How to donate", href: "https://benfeitoria.com/projeto/coqueconnecta" },
       { label: "Transparency", href: "/transparencia" },
     ],

--- a/src/features/admin/config/adminRoutes.ts
+++ b/src/features/admin/config/adminRoutes.ts
@@ -32,6 +32,7 @@ export const ADMIN_ROUTES: AdminRouteConfig[] = [
       { key: 'pages.home.waysToHelp',    label: 'Como Ajudar'    },
       { key: 'pages.home.stats',         label: 'Estatísticas'   },
       { key: 'pages.home.trust',         label: 'Confiança'      },
+      { key: 'pages.home.whatWeDo',      label: 'O que Fazemos'  },
     ],
   },
   {

--- a/src/features/admin/config/rtdbRouting.ts
+++ b/src/features/admin/config/rtdbRouting.ts
@@ -11,6 +11,7 @@ export const RTDB_SECTION_PATHS: Record<string, string> = {
   'pages.home.waysToHelp':    'cms/v3/pages/home/waysToHelp',
   'pages.home.stats':         'cms/v3/pages/home/stats',
   'pages.home.trust':         'cms/v3/pages/home/trust',
+  'pages.home.whatWeDo':      'cms/v3/pages/home/whatWeDo',
   'pages.projects':           'cms/v3/pages/projects',
   'pages.privacy':            'cms/v3/pages/privacy',
   'pages.transparency':       'cms/v3/pages/transparency',

--- a/src/features/admin/hooks/useAdminData.ts
+++ b/src/features/admin/hooks/useAdminData.ts
@@ -40,6 +40,7 @@ export function useAdminData(): UseAdminDataReturn {
               waysToHelp:    (home.waysToHelp    as Record<string, unknown>) ?? {},
               stats:         (home.stats         as Record<string, unknown>) ?? {},
               trust:         (home.trust         as Record<string, unknown>) ?? {},
+              whatWeDo:      (home.whatWeDo      as Record<string, unknown>) ?? {},
             },
             projects,
             privacy,

--- a/src/features/admin/routes/home/HomeRoute.tsx
+++ b/src/features/admin/routes/home/HomeRoute.tsx
@@ -7,6 +7,7 @@ import { WaysToHelpEditor } from './editors/WaysToHelpEditor';
 import { StatsEditor } from './editors/StatsEditor';
 import { AboutEditor } from './editors/AboutEditor';
 import { TrustEditor } from './editors/TrustEditor';
+import { WhatWeDoEditor } from './editors/WhatWeDoEditor';
 import type { AdminOutletContext } from '../types';
 
 const SECTIONS = [
@@ -119,6 +120,14 @@ export function HomeRoute() {
               onMoveArrayItem={(path, index, direction) => onMoveArrayItem(key, path, index, direction)}
               onDuplicateArrayItem={(path, index) => onDuplicateArrayItem(key, path, index)}
               renderImageField={(value, path, lbl, ph, ro) => renderImageField(key, value, path, lbl, ph, ro)}
+            />
+          )}
+          {key === 'pages.home.whatWeDo' && (
+            <WhatWeDoEditor
+              data={cmsData.pages.home.whatWeDo as any}
+              sectionKey={key}
+              isFieldDirty={(path) => isFieldDirty(path, key)}
+              onFieldChange={(path, value) => onFieldChange(key, path, value)}
             />
           )}
         </SectionCard>

--- a/src/features/admin/routes/home/editors/HeroEditor.tsx
+++ b/src/features/admin/routes/home/editors/HeroEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from 'react';
 import { AdminEditorCard } from '../../../components/shared/AdminEditorCard';
 import { AdminPreviewPanel } from '../../../components/shared/AdminPreviewPanel';
-import { adminPanelGridClass } from '../../../components/shared/adminEditorStyles';
+import { adminPanelGridClass, adminFieldLabelClass, getAdminSelectClass } from '../../../components/shared/adminEditorStyles';
 import { AdminInputField } from '../../../components/form/AdminInputField';
 import { AdminTextareaField } from '../../../components/form/AdminTextareaField';
 import { AdminAddButton } from '../../../components/shared/AdminAddButton';
@@ -18,7 +18,7 @@ type HeroEditorProps = {
     ctaHref?: { pt?: string; en?: string };
     secondaryCtaText?: { pt?: string; en?: string };
     secondaryCtaHref?: { pt?: string; en?: string };
-    photos?: Array<{ src?: string; alt?: string }>;
+    photos?: Array<{ src?: string; alt?: string; objectPosition?: string }>;
   };
   sectionKey: string;
   isFieldDirty: (path: Array<string | number>) => boolean;
@@ -38,8 +38,8 @@ function resolvePreviewData(data: HeroEditorProps['data'], language: CmsLanguage
 
   return {
     photos: (data.photos ?? [])
-      .filter((photo): photo is { src: string; alt?: string } => Boolean(photo.src))
-      .map((photo) => ({ src: photo.src, alt: photo.alt ?? '' })),
+      .filter((photo): photo is { src: string; alt?: string; objectPosition?: string } => Boolean(photo.src))
+      .map((photo) => ({ src: photo.src, alt: photo.alt ?? '', objectPosition: photo.objectPosition })),
     headline: pickLang(toI18nField(data.headline), language),
     subheadline: pickLang(toI18nField(data.subheadline), language),
     ctaText: pickLang(toI18nField(data.ctaText), language),
@@ -146,9 +146,25 @@ export function HeroEditor({
               isFieldDirty={isFieldDirty}
               onFieldChange={onFieldChange}
             />
+            <label className="block">
+              <span className={adminFieldLabelClass}>Ponto focal (recorte)</span>
+              <select
+                value={photo.objectPosition ?? ''}
+                onChange={(e) => onFieldChange(['photos', index, 'objectPosition'], e.target.value || undefined)}
+                className={getAdminSelectClass(isFieldDirty(['photos', index, 'objectPosition']))}
+              >
+                <option value="">Centro (padrão)</option>
+                <option value="top">Topo</option>
+                <option value="bottom">Baixo</option>
+                <option value="center 25%">Centro superior</option>
+                <option value="center 75%">Centro inferior</option>
+                <option value="left top">Esquerda superior</option>
+                <option value="right top">Direita superior</option>
+              </select>
+            </label>
           </CollapsibleItem>
         ))}
-        <AdminAddButton onClick={() => onAddArrayItem(['photos'], { src: '', alt: '' })}>Adicionar foto</AdminAddButton>
+        <AdminAddButton onClick={() => onAddArrayItem(['photos'], { src: '', alt: '', objectPosition: '' })}>Adicionar foto</AdminAddButton>
       </div>
 
       <AdminPreviewPanel language={previewLang} onLanguageChange={setPreviewLang}>

--- a/src/features/admin/routes/home/editors/WaysToHelpEditor.tsx
+++ b/src/features/admin/routes/home/editors/WaysToHelpEditor.tsx
@@ -23,6 +23,8 @@ type WaysToHelpCardType = {
   title?: I18nField;
   description?: I18nField;
   tags?: Array<{ pt?: string; en?: string }>;
+  ctaLabel?: I18nField;
+  ctaHref?: I18nField;
 };
 
 type WaysToHelpEditorProps = {
@@ -49,7 +51,9 @@ function resolvePreviewData(data: WaysToHelpEditorProps['data'], language: CmsLa
       variant: card.variant ?? 'light',
       title: pickLang(toI18nField(card.title), language),
       description: pickLang(toI18nField(card.description), language),
-      tags: (card.tags ?? []).map((tag) => pickLang(toI18nField(tag), language)),
+      tags:     (card.tags ?? []).map((tag) => pickLang(toI18nField(tag), language)),
+      ctaLabel: card.ctaLabel ? pickLang(toI18nField(card.ctaLabel), language) : undefined,
+      ctaHref:  card.ctaHref  ? pickLang(toI18nField(card.ctaHref),  language) : undefined,
     })),
   };
 }
@@ -134,6 +138,21 @@ export function WaysToHelpEditor({ data, isFieldDirty, onFieldChange, onAddArray
                   <Trash2 className="h-3 w-3" />
                 </button>
               </div>
+            ))}
+          </div>
+          {/* CTA por card */}
+          <div className={adminPanelGridClass}>
+            {(['pt', 'en'] as const).map((lang) => (
+              <AdminEditorCard key={lang} title={`CTA ${lang === 'pt' ? '(PT)' : '(EN)'}`}>
+                <label className="block">
+                  <span className={adminFieldLabelClass}>Texto do botão</span>
+                  <input type="text" value={card.ctaLabel?.[lang] ?? ''} onChange={(e) => onFieldChange(['cards', cardIndex, 'ctaLabel', lang], e.target.value)} className={getAdminInputClass(isFieldDirty(['cards', cardIndex, 'ctaLabel', lang]))} placeholder="Ex: Saiba como doar" />
+                </label>
+                <label className="block">
+                  <span className={adminFieldLabelClass}>URL do botão</span>
+                  <input type="text" value={card.ctaHref?.[lang] ?? ''} onChange={(e) => onFieldChange(['cards', cardIndex, 'ctaHref', lang], e.target.value)} className={getAdminInputClass(isFieldDirty(['cards', cardIndex, 'ctaHref', lang]))} placeholder="https://... ou /rota" />
+                </label>
+              </AdminEditorCard>
             ))}
           </div>
         </CollapsibleItem>

--- a/src/features/admin/routes/home/editors/WhatWeDoEditor.tsx
+++ b/src/features/admin/routes/home/editors/WhatWeDoEditor.tsx
@@ -1,0 +1,46 @@
+import { AdminEditorCard } from '../../../components/shared/AdminEditorCard';
+import { adminPanelGridClass } from '../../../components/shared/adminEditorStyles';
+import { AdminInputField } from '../../../components/form/AdminInputField';
+import { AdminTextareaField } from '../../../components/form/AdminTextareaField';
+
+type WhatWeDoEditorProps = {
+  data: {
+    headline?: { pt?: string; en?: string };
+    subtitle?: { pt?: string; en?: string };
+  };
+  sectionKey: string;
+  isFieldDirty: (path: Array<string | number>) => boolean;
+  onFieldChange: (path: Array<string | number>, value: unknown) => void;
+};
+
+export function WhatWeDoEditor({ data, isFieldDirty, onFieldChange }: WhatWeDoEditorProps) {
+  const langs = [
+    { lang: 'pt', label: 'Português (PT)' },
+    { lang: 'en', label: 'Inglês (EN)' },
+  ] as const;
+
+  return (
+    <div className={adminPanelGridClass}>
+      {langs.map(({ lang, label }) => (
+        <AdminEditorCard key={lang} title={label}>
+          <AdminInputField
+            label="Headline"
+            path={['headline', lang]}
+            value={data.headline?.[lang] ?? ''}
+            isFieldDirty={isFieldDirty}
+            onFieldChange={onFieldChange}
+            placeholder="O que Fazemos"
+          />
+          <AdminTextareaField
+            label="Subtítulo"
+            path={['subtitle', lang]}
+            value={data.subtitle?.[lang] ?? ''}
+            isFieldDirty={isFieldDirty}
+            onFieldChange={onFieldChange}
+            rows={3}
+          />
+        </AdminEditorCard>
+      ))}
+    </div>
+  );
+}

--- a/src/features/admin/types.ts
+++ b/src/features/admin/types.ts
@@ -23,6 +23,7 @@ export type CmsAdminState = {
       waysToHelp: CmsAdminData;
       stats: CmsAdminData;
       trust: CmsAdminData;
+      whatWeDo: CmsAdminData;
     };
     projects: CmsAdminData;
     privacy: CmsAdminData;

--- a/src/hooks/useCmsAboutData.ts
+++ b/src/hooks/useCmsAboutData.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import type { CmsLanguage, ResolvedAboutData } from '../types/cms';
+import { getCmsAboutData } from '../services/cmsService';
+
+const EMPTY: ResolvedAboutData = { description: '' };
+const inMemoryCache: Partial<Record<CmsLanguage, ResolvedAboutData>> = {};
+
+export function useCmsAboutData(language: CmsLanguage) {
+  const [data, setData] = useState<ResolvedAboutData>(inMemoryCache[language] ?? EMPTY);
+  const [isLoading, setIsLoading] = useState(!inMemoryCache[language]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (inMemoryCache[language]) {
+      setData(inMemoryCache[language]!);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    getCmsAboutData(language).then((resolved) => {
+      if (!isMounted) return;
+      inMemoryCache[language] = resolved;
+      setData(resolved);
+      setIsLoading(false);
+    }).catch(() => {
+      if (isMounted) setIsLoading(false);
+    });
+
+    return () => { isMounted = false; };
+  }, [language]);
+
+  return { data, isLoading };
+}

--- a/src/hooks/useCmsLandingData.ts
+++ b/src/hooks/useCmsLandingData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { CmsLanguage, ResolvedHeroData, ResolvedAboutData, ResolvedWaysToHelpData, ResolvedStatsData, ResolvedTrustData, ResolvedYoutubeVideo } from '../types/cms';
+import type { CmsLanguage, ResolvedHeroData, ResolvedAboutData, ResolvedWaysToHelpData, ResolvedStatsData, ResolvedTrustData, ResolvedYoutubeVideo, ResolvedWhatWeDoData } from '../types/cms';
 import type { CmsCarouselData } from '../types/cms';
 import {
   getCmsHeroData,
@@ -9,6 +9,7 @@ import {
   getCmsWaysToHelpData,
   getCmsStatsData,
   getCmsTrustData,
+  getCmsWhatWeDoData,
 } from '../services/cmsService';
 
 export interface CmsHomeData {
@@ -19,6 +20,7 @@ export interface CmsHomeData {
   waysToHelp: ResolvedWaysToHelpData;
   stats: ResolvedStatsData;
   trust: ResolvedTrustData;
+  whatWeDo: ResolvedWhatWeDoData;
 }
 
 const EMPTY_HOME: CmsHomeData = {
@@ -29,6 +31,7 @@ const EMPTY_HOME: CmsHomeData = {
   waysToHelp:    { headline: '', subtitle: '', cards: [] },
   stats:         { items: [] },
   trust:         { headline: '', subtitle: '', pressItems: [], partnerLogos: [] },
+  whatWeDo:      { headline: '', subtitle: '' },
 };
 
 const inMemoryCache: Partial<Record<CmsLanguage, CmsHomeData>> = {};
@@ -56,9 +59,10 @@ export function useCmsLandingData(language: CmsLanguage) {
       getCmsWaysToHelpData(language),
       getCmsStatsData(language),
       getCmsTrustData(language),
-    ]).then(([hero, about, carousel, youtubeVideos, waysToHelp, stats, trust]) => {
+      getCmsWhatWeDoData(language),
+    ]).then(([hero, about, carousel, youtubeVideos, waysToHelp, stats, trust, whatWeDo]) => {
       if (!isMounted) return;
-      const resolved: CmsHomeData = { hero, about, carousel, youtubeVideos, waysToHelp, stats, trust };
+      const resolved: CmsHomeData = { hero, about, carousel, youtubeVideos, waysToHelp, stats, trust, whatWeDo };
       inMemoryCache[language] = resolved;
       setData(resolved);
       setIsLoading(false);

--- a/src/hooks/useCmsWaysToHelpData.ts
+++ b/src/hooks/useCmsWaysToHelpData.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import type { CmsLanguage, ResolvedWaysToHelpData } from '../types/cms';
+import { getCmsWaysToHelpData } from '../services/cmsService';
+
+const EMPTY: ResolvedWaysToHelpData = { headline: '', subtitle: '', cards: [] };
+const inMemoryCache: Partial<Record<CmsLanguage, ResolvedWaysToHelpData>> = {};
+
+export function useCmsWaysToHelpData(language: CmsLanguage) {
+  const [data, setData] = useState<ResolvedWaysToHelpData>(inMemoryCache[language] ?? EMPTY);
+  const [isLoading, setIsLoading] = useState(!inMemoryCache[language]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (inMemoryCache[language]) {
+      setData(inMemoryCache[language]!);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    getCmsWaysToHelpData(language).then((resolved) => {
+      if (!isMounted) return;
+      inMemoryCache[language] = resolved;
+      setData(resolved);
+      setIsLoading(false);
+    }).catch(() => {
+      if (isMounted) setIsLoading(false);
+    });
+
+    return () => { isMounted = false; };
+  }, [language]);
+
+  return { data, isLoading };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,7 @@ html {
 #ways-to-help,
 #contact,
 #impact,
+#coque-em-acao,
 #videos,
 #photos,
 #trust {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,6 +5,14 @@ export const ROUTE_HASHES = {
   waysToHelp: '#ways-to-help',
 } as const;
 
+export const ROUTES = {
+  about:        '/quem-somos',
+  waysToHelp:   '/como-ajudar',
+  whatWeDo:     '/nossos-projetos',
+  transparency: '/transparencia',
+  privacy:      '/privacidade',
+} as const;
+
 export const STORAGE_KEYS = {
   language: 'site-coque-language',
   adminTheme: 'admin-theme',

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,22 @@
+import { useOutletContext } from 'react-router-dom';
+import { PageShell } from '../components/ui/PageShell';
+import { SectionHeader } from '../components/ui/SectionHeader';
+import { AboutSection } from '../components/sections/AboutSection';
+import type { PublicLayoutContextValue } from './PublicLayout';
+import { useCmsAboutData } from '../hooks/useCmsAboutData';
+
+const TITLE: Record<string, string> = { pt: 'Quem Somos', en: 'Who We Are' };
+
+export default function AboutPage() {
+  const { language } = useOutletContext<PublicLayoutContextValue>();
+  const { data, isLoading } = useCmsAboutData(language);
+
+  if (isLoading) return null;
+
+  return (
+    <PageShell>
+      <SectionHeader title={TITLE[language] ?? TITLE.pt} />
+      <AboutSection data={data} />
+    </PageShell>
+  );
+}

--- a/src/pages/PublicLayout.tsx
+++ b/src/pages/PublicLayout.tsx
@@ -55,7 +55,6 @@ export default function PublicLayout() {
       />
 
       <LanguageBar language={language} onLanguageChange={setLanguage} isFixed />
-
       <HeaderBar
         navLinks={navLinks}
         activeLink={activeLink}
@@ -64,6 +63,7 @@ export default function PublicLayout() {
         onNavClick={handleNavClick}
         onMobileMenuClick={() => setMobileMenuOpen(!mobileMenuOpen)}
         showMobileMenu={mobileMenuOpen}
+        isFixed
       />
 
       <Outlet context={{ language, setLanguage } satisfies PublicLayoutContextValue} />

--- a/src/pages/Site.tsx
+++ b/src/pages/Site.tsx
@@ -1,13 +1,16 @@
-import { useOutletContext } from 'react-router-dom';
+import { Link, useOutletContext } from 'react-router-dom';
 import { HeroSection } from '../components/sections/HeroSection';
 import { AboutSection } from '../components/sections/AboutSection';
-import { VideosSection } from '../components/sections/VideosSection';
-import { CarouselSection } from '../components/sections/CarouselSection';
-import { WaysToHelpSection } from '../components/sections/WaysToHelpSection';
+import { CoqueEmAcaoSection } from '../components/sections/CoqueEmAcaoSection';
+import { WaysToHelpTeaser } from '../components/sections/WaysToHelpTeaser';
 import { StatsSection } from '../components/sections/StatsSection';
 import { TrustSection } from '../components/sections/TrustSection';
+import { WhatWeDoSection } from '../components/sections/WhatWeDoSection';
+import { ROUTES } from '../lib/constants';
 import { useCmsLandingData } from '../hooks/useCmsLandingData';
 import type { PublicLayoutContextValue } from './PublicLayout';
+
+const ABOUT_LINK: Record<string, string> = { pt: 'Conheça nossa história →', en: 'Learn our story →' };
 
 function Site() {
   const { language } = useOutletContext<PublicLayoutContextValue>();
@@ -15,14 +18,26 @@ function Site() {
 
   return (
     <>
+      <div className="h-[116px] w-full bg-[color:var(--color-tag-bg)]" aria-hidden="true" />
       <HeroSection data={data.hero} />
 
       <main>
         <StatsSection data={data.stats} />
         <AboutSection data={data.about} />
-        <VideosSection videos={data.youtubeVideos} />
-        <CarouselSection images={data.carousel.images} />
-        <WaysToHelpSection data={data.waysToHelp} />
+        <div className="w-full bg-white pb-12 sm:pb-16">
+          <div className="mx-auto w-full max-w-[1440px] px-4 sm:px-6 lg:px-10">
+            <Link
+              to={ROUTES.about}
+              className="text-sm font-semibold text-[color:var(--color-tag-bg)] hover:underline"
+            >
+              {ABOUT_LINK[language] ?? ABOUT_LINK.pt}
+            </Link>
+          </div>
+        </div>
+        <CoqueEmAcaoSection videos={data.youtubeVideos} images={data.carousel.images} language={language} />
+        <WhatWeDoSection data={data.whatWeDo} language={language} />
+
+        <WaysToHelpTeaser data={data.waysToHelp} language={language} />
         <TrustSection data={data.trust} language={language} />
       </main>
     </>
@@ -30,4 +45,3 @@ function Site() {
 }
 
 export default Site;
-

--- a/src/pages/WaysToHelpPage.tsx
+++ b/src/pages/WaysToHelpPage.tsx
@@ -1,0 +1,18 @@
+import { useOutletContext } from 'react-router-dom';
+import { PageShell } from '../components/ui/PageShell';
+import { WaysToHelpSection } from '../components/sections/WaysToHelpSection';
+import type { PublicLayoutContextValue } from './PublicLayout';
+import { useCmsWaysToHelpData } from '../hooks/useCmsWaysToHelpData';
+
+export default function WaysToHelpPage() {
+  const { language } = useOutletContext<PublicLayoutContextValue>();
+  const { data, isLoading } = useCmsWaysToHelpData(language);
+
+  if (isLoading) return null;
+
+  return (
+    <PageShell>
+      <WaysToHelpSection data={data} />
+    </PageShell>
+  );
+}

--- a/src/services/cmsService.ts
+++ b/src/services/cmsService.ts
@@ -28,6 +28,8 @@ import type {
   ResolvedProject,
   ResolvedPrivacyData,
   ResolvedTransparencyData,
+  CmsWhatWeDoData,
+  ResolvedWhatWeDoData,
 } from '../types/cms';
 
 const V3 = 'cms/v3';
@@ -153,6 +155,8 @@ export async function getCmsWaysToHelpData(language: CmsLanguage): Promise<Resol
       title:       pickLang(card.title, language),
       description: pickLang(card.description, language),
       tags:        (card.tags ?? []).map((tag) => tag[language] ?? tag.pt),
+      ctaLabel:    card.ctaLabel ? pickLang(card.ctaLabel, language) : undefined,
+      ctaHref:     card.ctaHref  ? pickLang(card.ctaHref,  language) : undefined,
       blockquote:  card.blockquote ? {
         text: pickLang(card.blockquote.text, language),
         authorName: card.blockquote.authorName,
@@ -181,6 +185,15 @@ export async function getCmsTrustData(language: CmsLanguage): Promise<ResolvedTr
     subtitle:     pickLang(data.subtitle, language),
     pressItems:   data.pressItems ?? [],
     partnerLogos: data.partnerLogos ?? [],
+  };
+}
+
+export async function getCmsWhatWeDoData(language: CmsLanguage): Promise<ResolvedWhatWeDoData> {
+  const data = await fetchNode<CmsWhatWeDoData>(`${V3}/pages/home/whatWeDo`);
+  if (!data) return { headline: '', subtitle: '' };
+  return {
+    headline: pickLang(data.headline, language),
+    subtitle: pickLang(data.subtitle, language),
   };
 }
 

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -69,6 +69,7 @@ export interface CmsAboutData {
 export interface CmsCarouselImage {
   src: string;
   alt: string;
+  objectPosition?: string;
 }
 
 export interface CmsCarouselData {
@@ -96,6 +97,8 @@ export interface CmsWaysToHelpCard {
   title: I18nField;
   description: I18nField;
   tags: CmsWaysToHelpTag[];
+  ctaLabel?: I18nField;
+  ctaHref?: I18nField;
   blockquote?: {
     text: I18nField;
     authorName: string;
@@ -208,6 +211,8 @@ export interface ResolvedWaysToHelpCard {
   title: string;
   description: string;
   tags: string[];
+  ctaLabel?: string;
+  ctaHref?: string;
   blockquote?: {
     text: string;
     authorName: string;
@@ -219,6 +224,8 @@ export interface ResolvedStatItem    { value: string; label: string }
 export interface ResolvedStatsData   { items: ResolvedStatItem[] }
 export interface ResolvedTrustData   { headline: string; subtitle: string; pressItems: CmsPressItem[]; partnerLogos: CmsPartnerLogo[] }
 export interface ResolvedYoutubeVideo { id: string; title: string }
+export interface CmsWhatWeDoData { headline: I18nField; subtitle: I18nField }
+export interface ResolvedWhatWeDoData { headline: string; subtitle: string }
 export interface ResolvedProject {
   id: string; image: string; location: string; actionHref?: string;
   title: string; bodyMd: string; actionLabel: string;


### PR DESCRIPTION
## Summary
- Consolida Vídeos + Carrossel em uma única seção "Coque em ação"
- Carrossel de fotos no Hero com ponto focal configurável por foto (objectPosition via admin)
- Novas rotas dedicadas `/quem-somos` e `/como-ajudar` (com CTA por card)
- Teaser "Como Ajudar" + seção "O que Fazemos" (2 projetos) na home
- Fix: header fixo transparente com div escura (h-[116px]) antes do hero, evitando que o header sobreponha a foto no topo da página

## Test plan
- [x] `tsc --noEmit` limpo
- [x] `npm run build` limpo
- [x] `npm test` (11/11 passando)
- [x] Validado no preview do Vercel (staging)