### PR TITLE
style: impeccable home — ritmo cromático, hierarquia, SectionHeading, border-radius

### DIFF
--- a/.impeccable/critique/2026-06-30T22-33-19Z__src-components-ui-youtubefeed-youtubefeed-tsx.md
+++ b/.impeccable/critique/2026-06-30T22-33-19Z__src-components-ui-youtubefeed-youtubefeed-tsx.md
@@ -1,0 +1,31 @@
+---
+target: VideosSection
+total_score: 22
+p0_count: 0
+p1_count: 2
+timestamp: 2026-06-30T22-33-19Z
+slug: src-components-ui-youtubefeed-youtubefeed-tsx
+---
+## Design Health Score
+
+| # | Heurística | Score | Issue principal |
+|---|---|---|---|
+| 1 | Visibility of System Status | 2 | Sem estado de carregamento; overlay sempre bg-black/20 |
+| 2 | Match System / Real World | 3 | Play icon universal; thumbnail-como-preview padrão |
+| 3 | User Control and Freedom | 3 | Modal com ESC e fechar OK |
+| 4 | Consistency and Standards | 3 | Grid orphan quebra ritmo |
+| 5 | Error Prevention | 1 | maxresdefault retorna preto para vídeos recentes; sem fallback |
+| 6 | Recognition Rather Than Recall | 2 | Sem títulos; conteúdo só pela thumbnail |
+| 7 | Flexibility and Efficiency | 1 | div onClick — Tab pula todos os cards |
+| 8 | Aesthetic and Minimalist Design | 3 | Limpo; orphan é única ruptura |
+| 9 | Error Recovery | 1 | Thumbnail falha silenciosamente; sem onError |
+| 10 | Help and Documentation | 3 | N/A; affordances claros |
+| **Total** | | **22/40** | **Acceptable** |
+
+## Priority Issues
+
+P1: Grid orphan — 3º vídeo sozinho em meia-largura; fix: lg:grid-cols-3 + col-span-full condicional
+P1: div onClick inacessível — Tab pula todos os cards; fix: substituir por <button aria-label>
+P2: Sem títulos — reconhecimento depende 100% de thumbnail; fix: <p> com video.title + line-clamp-2
+P2: maxresdefault sem fallback — retorna preto para vídeos recentes; fix: onError fallback para hqdefault
+P3: Sem loading=lazy nas thumbnails

--- a/src/components/composites/HeaderBar/HeaderBar.tsx
+++ b/src/components/composites/HeaderBar/HeaderBar.tsx
@@ -59,7 +59,7 @@ export const HeaderBar = forwardRef<HTMLElement, HeaderBarProps>(
         )}
         {...props}
       >
-        <div className="mx-auto flex h-[84px] w-full items-center justify-between gap-4 overflow-visible rounded-[999px] bg-[rgba(244,212,194,0.82)] px-3 min-[380px]:px-5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] backdrop-blur-md sm:px-6 lg:gap-8 lg:px-8">
+        <div className="mx-auto flex h-[84px] w-full items-center justify-between gap-4 overflow-visible rounded-[var(--radius-pill)] bg-[rgba(244,212,194,0.82)] px-3 min-[380px]:px-5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] backdrop-blur-md sm:px-6 lg:gap-8 lg:px-8">
           {/* Logo */}
           <a href="/" className="flex shrink-0 items-center" aria-label="Coque Connecta">
             <CoqueConnectaWordmark className="h-6 w-[130px] min-[360px]:w-[145px] md:h-8 md:w-auto text-[color:var(--color-tag-bg)] lg:h-9" />
@@ -81,7 +81,7 @@ export const HeaderBar = forwardRef<HTMLElement, HeaderBarProps>(
               target="_blank"
               rel="noopener noreferrer"
               variant="unstyled"
-              className={cn('h-[58px] rounded-[50px] px-8 text-base leading-none', ctaBg)}
+              className={cn('h-[58px] rounded-[var(--radius-pill)] px-8 text-base leading-none', ctaBg)}
             >
               {ctaText}
             </Button>
@@ -95,7 +95,7 @@ export const HeaderBar = forwardRef<HTMLElement, HeaderBarProps>(
               rel="noopener noreferrer"
               variant="unstyled"
               className={cn(
-                'h-9 rounded-[50px] px-3 text-xs leading-none flex items-center justify-center font-medium min-[380px]:h-10 min-[380px]:px-4 min-[380px]:text-sm shrink-0',
+                'h-9 rounded-[var(--radius-pill)] px-3 text-xs leading-none flex items-center justify-center font-medium min-[380px]:h-10 min-[380px]:px-4 min-[380px]:text-sm shrink-0',
                 ctaBg
               )}
             >

--- a/src/components/composites/MobileMenuOverlay/MobileMenuOverlay.tsx
+++ b/src/components/composites/MobileMenuOverlay/MobileMenuOverlay.tsx
@@ -70,7 +70,7 @@ export const MobileMenuOverlay = forwardRef<HTMLDivElement, MobileMenuOverlayPro
               onClick={onClose}
               variant="ghost"
               size="sm"
-              className="rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+              className="rounded-[var(--radius-sm)] text-gray-500 hover:bg-gray-100 hover:text-gray-900"
               icon={<CloseIcon className="h-6 w-6" />}
               label="Fechar menu"
             />
@@ -94,7 +94,7 @@ export const MobileMenuOverlay = forwardRef<HTMLDivElement, MobileMenuOverlayPro
                   onClose?.();
                 }}
                 className={cn(
-                  'block rounded-md px-3 py-2 text-base font-semibold transition-colors',
+                  'block rounded-[var(--radius-sm)] px-3 py-2 text-base font-semibold transition-colors',
                   activeLink === link.href
                     ? 'bg-orange-50 text-orange-600'
                     : 'text-gray-900 hover:bg-gray-50'
@@ -114,7 +114,7 @@ export const MobileMenuOverlay = forwardRef<HTMLDivElement, MobileMenuOverlayPro
                 onNavClick?.(ctaHref);
                 onClose?.();
               }}
-              className="block w-full rounded-lg bg-orange-600 px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-orange-700"
+              className="block w-full rounded-[var(--radius-pill)] bg-orange-600 px-4 py-2 text-center font-semibold text-white transition-colors hover:bg-orange-700"
             >
               {ctaText}
             </Button>
@@ -130,14 +130,14 @@ export const MobileMenuOverlay = forwardRef<HTMLDivElement, MobileMenuOverlayPro
                 <Input
                   type="email"
                   placeholder="seu@email.com"
-                  className="rounded-md px-3 py-2 text-sm"
+                  className="rounded-[var(--radius-pill)] px-3 py-2 text-sm"
                   aria-label="Email para newsletter"
                 />
                 <Button
                   type="submit"
                   variant="unstyled"
                   fullWidth
-                  className="rounded-md bg-gray-900 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+                  className="rounded-[var(--radius-pill)] bg-gray-900 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
                 >
                   Inscrever
                 </Button>

--- a/src/components/composites/ProjectCard.tsx
+++ b/src/components/composites/ProjectCard.tsx
@@ -19,7 +19,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-black/5">
+    <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-md)] bg-white shadow-[var(--shadow-soft)]">
       {/* Image Container */}
       <div className="relative aspect-[4/3] w-full overflow-hidden bg-gray-100">
         <img

--- a/src/components/composites/ProjectCard.tsx
+++ b/src/components/composites/ProjectCard.tsx
@@ -55,9 +55,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <Button
               href={project.actionHref || '#'}
               variant="primary"
-              className="h-9 px-6 py-2 text-[11px] font-bold uppercase tracking-wider"
+              className="h-9 px-6 py-2 text-[11px] font-bold tracking-wider"
             >
-              {project.actionLabel || 'SAIBA MAIS'}
+              {project.actionLabel || 'Saiba mais'}
             </Button>
           </div>
         )}

--- a/src/components/composites/SectionCTA/SectionCTA.tsx
+++ b/src/components/composites/SectionCTA/SectionCTA.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom';
+import { cn } from '../../../lib/cn';
+
+export interface SectionCTAProps {
+  label: string;
+  href: string;
+  tone?: 'on-light' | 'on-dark' | 'on-orange';
+  className?: string;
+}
+
+const toneClasses: Record<NonNullable<SectionCTAProps['tone']>, string> = {
+  'on-light':
+    'bg-[color:var(--color-tag-bg)] text-[color:var(--color-text-on-dark)] hover:brightness-110',
+  'on-dark':
+    'bg-[color:var(--color-accent-peach)] text-[color:var(--color-tag-bg)] hover:brightness-95',
+  'on-orange':
+    'bg-white/95 text-[color:var(--color-tag-bg)] hover:bg-white',
+};
+
+const isExternal = (href: string) => /^https?:\/\//.test(href);
+
+export const SectionCTA = ({ label, href, tone = 'on-light', className }: SectionCTAProps) => {
+  const classes = cn(
+    'inline-flex items-center gap-1.5 rounded-[var(--radius-pill)] px-5 h-9 text-sm font-semibold tracking-tight transition-all',
+    toneClasses[tone],
+    className
+  );
+
+  if (isExternal(href)) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={classes}>
+        {label} →
+      </a>
+    );
+  }
+
+  return (
+    <Link to={href} className={classes}>
+      {label} →
+    </Link>
+  );
+};

--- a/src/components/composites/SectionHeading.tsx
+++ b/src/components/composites/SectionHeading.tsx
@@ -11,7 +11,7 @@ export interface SectionHeadingProps {
   subtitle?: string;
   size?: 'sm' | 'md' | 'lg';
   centered?: boolean;
-  tone?: 'default' | 'on-orange';
+  tone?: 'default' | 'on-orange' | 'on-dark';
   className?: string;
 }
 
@@ -24,9 +24,13 @@ export const SectionHeading = ({
   className,
 }: SectionHeadingProps) => {
   const headlineColor =
-    tone === 'on-orange' ? 'var(--color-tag-bg)' : 'var(--color-text-primary)';
+    tone === 'on-orange' ? 'var(--color-tag-bg)'
+    : tone === 'on-dark' ? 'var(--color-text-cream)'
+    : 'var(--color-text-primary)';
   const subtitleColor =
-    tone === 'on-orange' ? 'var(--color-tag-bg)' : 'var(--color-text-secondary)';
+    tone === 'on-orange' ? 'var(--color-tag-bg)'
+    : tone === 'on-dark' ? 'var(--color-text-cream)'
+    : 'var(--color-text-secondary)';
 
   return (
     <div className={cn('flex flex-col gap-4', centered && 'items-center text-center', className)}>
@@ -54,7 +58,7 @@ export const SectionHeading = ({
             color: subtitleColor,
             maxWidth: centered ? '55ch' : '60ch',
             margin: centered ? '0 auto' : 0,
-            opacity: tone === 'on-orange' ? 0.8 : 1,
+            opacity: tone === 'on-orange' ? 0.8 : tone === 'on-dark' ? 0.7 : 1,
           }}
         >
           {subtitle}

--- a/src/components/composites/SectionHeading.tsx
+++ b/src/components/composites/SectionHeading.tsx
@@ -1,0 +1,67 @@
+import { cn } from '../../lib/cn';
+
+const fontSizeBySize = {
+  sm: 'clamp(26px, 3.2vw, 38px)',
+  md: 'clamp(34px, 4.2vw, 50px)',
+  lg: 'clamp(38px, 4.8vw, 56px)',
+} as const;
+
+export interface SectionHeadingProps {
+  headline: string;
+  subtitle?: string;
+  size?: 'sm' | 'md' | 'lg';
+  centered?: boolean;
+  tone?: 'default' | 'on-orange';
+  className?: string;
+}
+
+export const SectionHeading = ({
+  headline,
+  subtitle,
+  size = 'md',
+  centered = false,
+  tone = 'default',
+  className,
+}: SectionHeadingProps) => {
+  const headlineColor =
+    tone === 'on-orange' ? 'var(--color-tag-bg)' : 'var(--color-text-primary)';
+  const subtitleColor =
+    tone === 'on-orange' ? 'var(--color-tag-bg)' : 'var(--color-text-secondary)';
+
+  return (
+    <div className={cn('flex flex-col gap-4', centered && 'items-center text-center', className)}>
+      <h3
+        style={{
+          fontFamily: "'Figtree', sans-serif",
+          fontSize: fontSizeBySize[size],
+          fontWeight: 700,
+          color: headlineColor,
+          lineHeight: '1.1',
+          margin: centered ? '0 auto' : 0,
+          letterSpacing: '-0.8px',
+          maxWidth: '640px',
+          textWrap: 'balance',
+        } as React.CSSProperties}
+      >
+        {headline}
+      </h3>
+      {subtitle && (
+        <p
+          style={{
+            fontFamily: "'Figtree', sans-serif",
+            fontSize: 'clamp(17px, 2vw, 20px)',
+            lineHeight: '1.5',
+            color: subtitleColor,
+            maxWidth: centered ? '55ch' : '60ch',
+            margin: centered ? '0 auto' : 0,
+            opacity: tone === 'on-orange' ? 0.8 : 1,
+          }}
+        >
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+};
+
+SectionHeading.displayName = 'SectionHeading';

--- a/src/components/sections/AboutSection/AboutSection.tsx
+++ b/src/components/sections/AboutSection/AboutSection.tsx
@@ -35,7 +35,8 @@ export const AboutSection = ({
             <div className="min-w-0">
               <Typography
                 variant="body"
-                className="text-[18px] leading-relaxed sm:text-[20px] lg:text-[22px] text-[color:var(--color-text-cream)]"
+                tone="onDark"
+                className="text-[18px] leading-relaxed sm:text-[20px] lg:text-[22px]"
               >
                 {data.description}
               </Typography>

--- a/src/components/sections/AboutSection/AboutSection.tsx
+++ b/src/components/sections/AboutSection/AboutSection.tsx
@@ -16,7 +16,7 @@ export const AboutSection = ({
   return (
     <section
       id="about"
-      className={cn('w-full bg-white pt-16 pb-0 md:pt-24 md:pb-0', className)}
+      className={cn('w-full bg-[color:var(--color-tag-bg)] py-20 sm:py-28', className)}
       {...props}
     >
       <Block>
@@ -35,8 +35,7 @@ export const AboutSection = ({
             <div className="min-w-0">
               <Typography
                 variant="body"
-                tone="muted"
-                className="text-[18px] leading-relaxed sm:text-[20px] lg:text-[22px]"
+                className="text-[18px] leading-relaxed sm:text-[20px] lg:text-[22px] text-[color:var(--color-text-cream)]"
               >
                 {data.description}
               </Typography>

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -41,7 +41,7 @@ export const CoqueEmAcaoSection = ({
       {...props}
     >
       <Block>
-        <FadeIn className="mb-10 flex flex-col gap-4">
+        <FadeIn className="mb-6 flex flex-col gap-4">
           <h3
             style={{
               fontFamily: "'Figtree', sans-serif",
@@ -72,7 +72,7 @@ export const CoqueEmAcaoSection = ({
         </FadeIn>
       </Block>
 
-      <div className="space-y-10 md:space-y-12">
+      <div className="space-y-6 md:space-y-8">
         <VideosSection videos={videos} className="py-0" />
         <CarouselSection images={images} className="py-0" />
       </div>

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -15,14 +15,18 @@ export interface CoqueEmAcaoSectionProps extends React.HTMLAttributes<HTMLElemen
 // Heading fixo (não-CMS) que une 2 seções de mídia independentes sob 1 narrativa só —
 // mesmo motivo do label de Transparência em TrustSection: é moldura editorial, não
 // conteúdo dinâmico, não justifica um campo i18n próprio no CMS.
-const HEADING: Record<CmsLanguage, { title: string; description: string }> = {
+const HEADING: Record<CmsLanguage, { title: string; description: string; youtubeLabel: string; photosLabel: string }> = {
   pt: {
     title: 'Coque em ação',
     description: 'Um retrato em vídeo e fotos do que a comunidade constrói todos os dias.',
+    youtubeLabel: 'Ver canal no YouTube',
+    photosLabel: 'Fotos',
   },
   en: {
     title: 'Coque in action',
     description: 'A look in video and photos at what the community builds every day.',
+    youtubeLabel: 'View YouTube channel',
+    photosLabel: 'Photos',
   },
 };
 
@@ -47,10 +51,27 @@ export const CoqueEmAcaoSection = ({
         </FadeIn>
       </Block>
 
-      <div className="space-y-6 md:space-y-8">
-        <VideosSection videos={videos} className="py-0" />
-        <CarouselSection images={images} className="py-0" />
-      </div>
+      <VideosSection videos={videos} className="py-0" showTitle={false} />
+
+      <Block className="mt-6 md:mt-8">
+        <div className="flex flex-col gap-5">
+          <a
+            href="https://www.youtube.com/@CoqueConnecta"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-[color:var(--color-accent-peach)] hover:text-[color:var(--color-tag-bg)] hover:underline"
+          >
+            {copy.youtubeLabel} →
+          </a>
+          <div className="flex items-center gap-3 border-t border-[color:var(--color-border-subtle)] pt-5">
+            <span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-secondary)]">
+              {copy.photosLabel}
+            </span>
+          </div>
+        </div>
+      </Block>
+
+      <CarouselSection images={images} className="mt-4 py-0" />
     </section>
   );
 };

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -20,13 +20,13 @@ const HEADING: Record<CmsLanguage, { title: string; description: string; youtube
   pt: {
     title: 'Coque em ação',
     description: 'Um retrato em vídeo e fotos do que a comunidade constrói todos os dias.',
-    youtubeLabel: 'Ver canal no YouTube',
+    youtubeLabel: 'Ver perfil no Instagram',
     photosLabel: 'Fotos',
   },
   en: {
     title: 'Coque in action',
     description: 'A look in video and photos at what the community builds every day.',
-    youtubeLabel: 'View YouTube channel',
+    youtubeLabel: 'Check Instagram profile',
     photosLabel: 'Photos',
   },
 };
@@ -56,7 +56,7 @@ export const CoqueEmAcaoSection = ({
 
       <Block className="mt-6 md:mt-8">
         <div className="flex flex-col gap-5">
-          <SectionCTA href="https://www.youtube.com/@CoqueConnecta" label={copy.youtubeLabel} className="self-start" />
+          <SectionCTA href="https://www.instagram.com/coqueconnecta" label={copy.youtubeLabel} className="self-start" />
           <div className="flex items-center gap-3 border-t border-[color:var(--color-border-subtle)] pt-5">
             <span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-secondary)]">
               {copy.photosLabel}

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -2,6 +2,7 @@ import { cn } from '../../../lib/cn';
 import type { CmsCarouselImage, CmsLanguage, ResolvedYoutubeVideo } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { FadeIn } from '../../ui/FadeIn';
+import { SectionHeading } from '../../composites/SectionHeading';
 import { VideosSection } from '../VideosSection';
 import { CarouselSection } from '../CarouselSection';
 
@@ -41,34 +42,8 @@ export const CoqueEmAcaoSection = ({
       {...props}
     >
       <Block>
-        <FadeIn className="mb-6 flex flex-col gap-4">
-          <h3
-            style={{
-              fontFamily: "'Figtree', sans-serif",
-              fontSize: 'clamp(34px, 4.2vw, 50px)',
-              fontWeight: 700,
-              color: 'var(--color-text-primary)',
-              lineHeight: '1.1',
-              margin: 0,
-              letterSpacing: '-0.8px',
-              maxWidth: '640px',
-              textWrap: 'balance',
-            } as React.CSSProperties}
-          >
-            {copy.title}
-          </h3>
-          <p
-            style={{
-              fontFamily: "'Figtree', sans-serif",
-              fontSize: 'clamp(17px, 2vw, 20px)',
-              lineHeight: '1.5',
-              color: 'var(--color-text-secondary)',
-              maxWidth: '60ch',
-              margin: 0,
-            }}
-          >
-            {copy.description}
-          </p>
+        <FadeIn className="mb-6">
+          <SectionHeading headline={copy.title} subtitle={copy.description} size="sm" />
         </FadeIn>
       </Block>
 

--- a/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
+++ b/src/components/sections/CoqueEmAcaoSection/CoqueEmAcaoSection.tsx
@@ -2,6 +2,7 @@ import { cn } from '../../../lib/cn';
 import type { CmsCarouselImage, CmsLanguage, ResolvedYoutubeVideo } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { FadeIn } from '../../ui/FadeIn';
+import { SectionCTA } from '../../composites/SectionCTA/SectionCTA';
 import { SectionHeading } from '../../composites/SectionHeading';
 import { VideosSection } from '../VideosSection';
 import { CarouselSection } from '../CarouselSection';
@@ -55,14 +56,7 @@ export const CoqueEmAcaoSection = ({
 
       <Block className="mt-6 md:mt-8">
         <div className="flex flex-col gap-5">
-          <a
-            href="https://www.youtube.com/@CoqueConnecta"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm font-semibold text-[color:var(--color-accent-peach)] hover:text-[color:var(--color-tag-bg)] hover:underline"
-          >
-            {copy.youtubeLabel} →
-          </a>
+          <SectionCTA href="https://www.youtube.com/@CoqueConnecta" label={copy.youtubeLabel} className="self-start" />
           <div className="flex items-center gap-3 border-t border-[color:var(--color-border-subtle)] pt-5">
             <span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-secondary)]">
               {copy.photosLabel}

--- a/src/components/sections/NewsletterSection/NewsletterSection.tsx
+++ b/src/components/sections/NewsletterSection/NewsletterSection.tsx
@@ -14,7 +14,7 @@ export interface NewsletterSectionProps extends React.HTMLAttributes<HTMLElement
 }
 
 const fieldBase =
-  'h-[54px] w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[#fafafa] px-6 text-[16px] text-[color:var(--color-text-primary)] placeholder:text-gray-500 [font-family:var(--font-body)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-brown)] focus-visible:ring-offset-1';
+  'h-[54px] w-full rounded-[var(--radius-pill)] border border-[color:var(--color-border-subtle)] bg-[#fafafa] px-6 text-[16px] text-[color:var(--color-text-primary)] placeholder:text-gray-500 [font-family:var(--font-body)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-brown)] focus-visible:ring-offset-1';
 
 export const NewsletterSection = ({ data, previewMode, className, ...props }: NewsletterSectionProps) => {
   const [loading, setLoading] = useState(false);
@@ -168,7 +168,7 @@ export const NewsletterSection = ({ data, previewMode, className, ...props }: Ne
                 <button
                   type="submit"
                   disabled={loading || !formData.consent}
-                  className="mt-4 h-[54px] w-full sm:w-auto self-center rounded-full bg-[color:var(--color-accent-peach)] px-10 text-[18px] font-semibold tracking-tight text-[color:var(--color-accent-brown)] [font-family:var(--font-body)] transition-transform active:scale-95 disabled:opacity-70 disabled:cursor-not-allowed hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-brown)] focus-visible:ring-offset-2"
+                  className="mt-4 h-[54px] w-full sm:w-auto self-center rounded-[var(--radius-pill)] bg-[color:var(--color-accent-peach)] px-10 text-[18px] font-semibold tracking-tight text-[color:var(--color-accent-brown)] [font-family:var(--font-body)] transition-transform active:scale-95 disabled:opacity-70 disabled:cursor-not-allowed hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-brown)] focus-visible:ring-offset-2"
                 >
                   {loading ? 'ENVIANDO...' : data.buttonText || 'RECEBER'}
                 </button>

--- a/src/components/sections/StatsSection/StatsSection.tsx
+++ b/src/components/sections/StatsSection/StatsSection.tsx
@@ -15,7 +15,7 @@ export const StatsSection = ({ data, className, ...props }: StatsSectionProps) =
       {...props}
     >
       <Block className="py-16 sm:py-20">
-        <div className="grid grid-cols-1 gap-x-[60px] gap-y-[60px] sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-16 sm:grid-cols-2 lg:grid-cols-4">
           {data.items.map((stat, index) => (
             <FadeIn key={index} delay={index * 100} className="flex flex-col items-center gap-3 text-center">
               <p

--- a/src/components/sections/TrustSection/TrustSection.tsx
+++ b/src/components/sections/TrustSection/TrustSection.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../../lib/cn';
 import type { CmsLanguage, ResolvedTrustData } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { FadeIn } from '../../ui/FadeIn';
+import { SectionHeading } from '../../composites/SectionHeading';
 
 export interface TrustSectionProps extends React.HTMLAttributes<HTMLElement> {
   data: ResolvedTrustData;
@@ -25,34 +26,8 @@ export const TrustSection = ({ data, language, className, ...props }: TrustSecti
       {...props}
     >
       <Block>
-        <FadeIn className="mb-10 flex flex-col gap-4">
-          <h3
-            style={{
-              fontFamily: "'Figtree', sans-serif",
-              fontSize: 'clamp(34px, 4.2vw, 50px)',
-              fontWeight: 700,
-              color: 'var(--color-text-primary)',
-              lineHeight: '1.1',
-              margin: 0,
-              letterSpacing: '-0.8px',
-              maxWidth: '640px',
-              textWrap: 'balance',
-            } as React.CSSProperties}
-          >
-            {data.headline}
-          </h3>
-          <p
-            style={{
-              fontFamily: "'Figtree', sans-serif",
-              fontSize: 'clamp(17px, 2vw, 20px)',
-              lineHeight: '1.5',
-              color: 'var(--color-text-secondary)',
-              maxWidth: '60ch',
-              margin: 0,
-            }}
-          >
-            {data.subtitle}
-          </p>
+        <FadeIn className="mb-10">
+          <SectionHeading headline={data.headline} subtitle={data.subtitle} size="sm" />
         </FadeIn>
 
         {data.pressItems.length > 0 && (

--- a/src/components/sections/TrustSection/TrustSection.tsx
+++ b/src/components/sections/TrustSection/TrustSection.tsx
@@ -22,29 +22,33 @@ export const TrustSection = ({ data, language, className, ...props }: TrustSecti
   return (
     <section
       id="trust"
-      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      className={cn('w-full bg-[color:var(--color-tag-bg)] py-16 sm:py-20', className)}
       {...props}
     >
       <Block>
         <FadeIn className="mb-10">
-          <SectionHeading headline={data.headline} subtitle={data.subtitle} size="sm" />
+          <SectionHeading headline={data.headline} subtitle={data.subtitle} size="sm" tone="on-dark" />
         </FadeIn>
 
         {data.pressItems.length > 0 && (
-          <div className="mb-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="mb-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {data.pressItems.map((item, index) => (
               <FadeIn key={index} delay={Math.min(index * 80, 240)}>
                 <a
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex h-full flex-col gap-2 rounded-[var(--radius-xl)] border border-[var(--color-border-subtle)] p-5 transition-colors hover:border-[var(--color-tag-bg)]"
+                  className="flex h-full flex-col gap-3 rounded-[var(--radius-lg)] bg-white/8 border border-white/10 p-5 transition-colors hover:bg-white/12"
                 >
-                  <span className="flex items-center justify-between gap-2 text-sm font-semibold text-[var(--color-text-primary)]">
-                    {item.outlet}
-                    <ExternalLink className="h-4 w-4 shrink-0 text-[var(--color-text-secondary)]" aria-hidden="true" />
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold tracking-wide text-[color:var(--color-accent-peach)]">
+                      {item.outlet}
+                    </span>
+                    <ExternalLink className="h-3.5 w-3.5 shrink-0 text-[color:var(--color-accent-peach)]/60" aria-hidden="true" />
                   </span>
-                  <span className="text-sm leading-relaxed text-[var(--color-text-secondary)]">{item.title}</span>
+                  <span className="text-sm font-medium leading-relaxed text-[color:var(--color-text-cream)]">
+                    {item.title}
+                  </span>
                 </a>
               </FadeIn>
             ))}
@@ -54,13 +58,13 @@ export const TrustSection = ({ data, language, className, ...props }: TrustSecti
         {data.partnerLogos.length > 0 && (
           <div className="mb-10 flex flex-wrap items-center gap-8">
             {data.partnerLogos.map((logo, index) => (
-              <span key={index} className="inline-flex">
+              <span key={index} className="inline-flex opacity-60 transition-opacity hover:opacity-90">
                 {logo.url ? (
                   <a href={logo.url} target="_blank" rel="noopener noreferrer">
-                    <img src={logo.src} alt={logo.alt} className="h-10 w-auto object-contain" loading="lazy" />
+                    <img src={logo.src} alt={logo.alt} className="h-10 w-auto object-contain brightness-0 invert" loading="lazy" />
                   </a>
                 ) : (
-                  <img src={logo.src} alt={logo.alt} className="h-10 w-auto object-contain" loading="lazy" />
+                  <img src={logo.src} alt={logo.alt} className="h-10 w-auto object-contain brightness-0 invert" loading="lazy" />
                 )}
               </span>
             ))}
@@ -69,7 +73,7 @@ export const TrustSection = ({ data, language, className, ...props }: TrustSecti
 
         <Link
           to="/transparencia"
-          className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--color-tag-bg)] hover:underline"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-[color:var(--color-accent-peach)] hover:text-[color:var(--color-text-cream)] hover:underline"
         >
           {TRANSPARENCY_LINK_LABEL[language]}
         </Link>

--- a/src/components/sections/VideosSection/VideosSection.tsx
+++ b/src/components/sections/VideosSection/VideosSection.tsx
@@ -6,10 +6,12 @@ import type { ResolvedYoutubeVideo } from '../../../types/cms';
 
 export interface VideosSectionProps extends React.HTMLAttributes<HTMLElement> {
   videos?: ResolvedYoutubeVideo[];
+  showTitle?: boolean;
 }
 
 export const VideosSection = ({
   videos,
+  showTitle,
   className,
   ...props
 }: VideosSectionProps) => {
@@ -21,7 +23,7 @@ export const VideosSection = ({
     >
       <Block>
         <FadeIn>
-          <YouTubeFeed videos={videos} />
+          <YouTubeFeed videos={videos} showTitle={showTitle} />
         </FadeIn>
       </Block>
     </section>

--- a/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
+++ b/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
@@ -19,20 +19,20 @@ export const WaysToHelpTeaser = ({ data, language, className, ...props }: WaysTo
   return (
     <section
       id="ways-to-help"
-      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      className={cn('w-full bg-[color:var(--color-surface-orange)] py-20 sm:py-28', className)}
       {...props}
     >
       <Block>
-        <FadeIn className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4">
+        <FadeIn className="flex flex-col items-center gap-6 text-center">
+          <div className="flex flex-col items-center gap-4">
             <h3
               style={{
                 fontFamily: "'Figtree', sans-serif",
                 fontSize: 'clamp(34px, 4.2vw, 50px)',
                 fontWeight: 700,
-                color: 'var(--color-text-primary)',
+                color: 'var(--color-tag-bg)',
                 lineHeight: '1.1',
-                margin: 0,
+                margin: '0 auto',
                 letterSpacing: '-0.8px',
                 maxWidth: '640px',
                 textWrap: 'balance',
@@ -46,16 +46,22 @@ export const WaysToHelpTeaser = ({ data, language, className, ...props }: WaysTo
                   fontFamily: "'Figtree', sans-serif",
                   fontSize: 'clamp(17px, 2vw, 20px)',
                   lineHeight: '1.5',
-                  color: 'var(--color-text-secondary)',
+                  color: 'var(--color-tag-bg)',
                   maxWidth: '60ch',
-                  margin: 0,
+                  margin: '0 auto',
+                  opacity: 0.8,
                 }}
               >
                 {data.subtitle}
               </p>
             )}
           </div>
-          <Button href={ROUTES.waysToHelp} variant="primary" size="lg">
+          <Button
+            href={ROUTES.waysToHelp}
+            variant="unstyled"
+            size="lg"
+            className="bg-[color:var(--color-tag-bg)] text-[color:var(--color-accent-peach)] hover:brightness-110 px-8 py-3 h-12 text-base font-semibold rounded-md"
+          >
             {CTA_LABEL[language]}
           </Button>
         </FadeIn>

--- a/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
+++ b/src/components/sections/WaysToHelpTeaser/WaysToHelpTeaser.tsx
@@ -3,6 +3,7 @@ import type { CmsLanguage, ResolvedWaysToHelpData } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { FadeIn } from '../../ui/FadeIn';
 import { Button } from '../../ui/Button';
+import { SectionHeading } from '../../composites/SectionHeading';
 import { ROUTES } from '../../../lib/constants';
 
 export interface WaysToHelpTeaserProps extends React.HTMLAttributes<HTMLElement> {
@@ -23,44 +24,19 @@ export const WaysToHelpTeaser = ({ data, language, className, ...props }: WaysTo
       {...props}
     >
       <Block>
-        <FadeIn className="flex flex-col items-center gap-6 text-center">
-          <div className="flex flex-col items-center gap-4">
-            <h3
-              style={{
-                fontFamily: "'Figtree', sans-serif",
-                fontSize: 'clamp(34px, 4.2vw, 50px)',
-                fontWeight: 700,
-                color: 'var(--color-tag-bg)',
-                lineHeight: '1.1',
-                margin: '0 auto',
-                letterSpacing: '-0.8px',
-                maxWidth: '640px',
-                textWrap: 'balance',
-              } as React.CSSProperties}
-            >
-              {data.headline}
-            </h3>
-            {data.subtitle && (
-              <p
-                style={{
-                  fontFamily: "'Figtree', sans-serif",
-                  fontSize: 'clamp(17px, 2vw, 20px)',
-                  lineHeight: '1.5',
-                  color: 'var(--color-tag-bg)',
-                  maxWidth: '60ch',
-                  margin: '0 auto',
-                  opacity: 0.8,
-                }}
-              >
-                {data.subtitle}
-              </p>
-            )}
-          </div>
+        <FadeIn className="flex flex-col items-center gap-6">
+          <SectionHeading
+            headline={data.headline}
+            subtitle={data.subtitle}
+            size="lg"
+            centered
+            tone="on-orange"
+          />
           <Button
             href={ROUTES.waysToHelp}
             variant="unstyled"
             size="lg"
-            className="bg-[color:var(--color-tag-bg)] text-[color:var(--color-accent-peach)] hover:brightness-110 px-8 py-3 h-12 text-base font-semibold rounded-md"
+            className="bg-[color:var(--color-tag-bg)] text-[color:var(--color-accent-peach)] hover:brightness-110 px-8 py-3 h-12 text-base font-semibold"
           >
             {CTA_LABEL[language]}
           </Button>

--- a/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
+++ b/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
@@ -2,9 +2,9 @@ import { cn } from '../../../lib/cn';
 import type { CmsLanguage, ResolvedWhatWeDoData } from '../../../types/cms';
 import { Block } from '../../ui/Block';
 import { FadeIn } from '../../ui/FadeIn';
-import { Button } from '../../ui/Button';
 import { ProjectCard } from '../../composites/ProjectCard';
 import { ProjectGrid } from '../../composites/ProjectGrid';
+import { SectionCTA } from '../../composites/SectionCTA/SectionCTA';
 import { SectionHeading } from '../../composites/SectionHeading';
 import { ROUTES } from '../../../lib/constants';
 import { useCmsProjectsData } from '../../../hooks/useCmsProjectsData';
@@ -15,8 +15,8 @@ export interface WhatWeDoSectionProps extends React.HTMLAttributes<HTMLElement> 
 }
 
 const SEE_ALL_LABEL: Record<CmsLanguage, string> = {
-  pt: 'Ver todos os projetos →',
-  en: 'See all projects →',
+  pt: 'Ver todos os projetos',
+  en: 'See all projects',
 };
 
 export const WhatWeDoSection = ({
@@ -54,9 +54,7 @@ export const WhatWeDoSection = ({
         )}
 
         <div className="mt-8">
-          <Button href={ROUTES.whatWeDo} variant="primary">
-            {SEE_ALL_LABEL[language]}
-          </Button>
+          <SectionCTA href={ROUTES.whatWeDo} label={SEE_ALL_LABEL[language]} />
         </div>
       </Block>
     </section>

--- a/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
+++ b/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
@@ -30,7 +30,7 @@ export const WhatWeDoSection = ({
   return (
     <section
       id="what-we-do"
-      className={cn('w-full bg-white py-12 sm:py-16', className)}
+      className={cn('w-full bg-[color:var(--color-surface-page)] py-12 sm:py-16', className)}
       {...props}
     >
       <Block>

--- a/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
+++ b/src/components/sections/WhatWeDoSection/WhatWeDoSection.tsx
@@ -5,6 +5,7 @@ import { FadeIn } from '../../ui/FadeIn';
 import { Button } from '../../ui/Button';
 import { ProjectCard } from '../../composites/ProjectCard';
 import { ProjectGrid } from '../../composites/ProjectGrid';
+import { SectionHeading } from '../../composites/SectionHeading';
 import { ROUTES } from '../../../lib/constants';
 import { useCmsProjectsData } from '../../../hooks/useCmsProjectsData';
 
@@ -34,36 +35,12 @@ export const WhatWeDoSection = ({
       {...props}
     >
       <Block>
-        <FadeIn className="mb-10 flex flex-col gap-4">
-          <h3
-            style={{
-              fontFamily: "'Figtree', sans-serif",
-              fontSize: 'clamp(34px, 4.2vw, 50px)',
-              fontWeight: 700,
-              color: 'var(--color-text-primary)',
-              lineHeight: '1.1',
-              margin: 0,
-              letterSpacing: '-0.8px',
-              maxWidth: '640px',
-              textWrap: 'balance',
-            } as React.CSSProperties}
-          >
-            {data.headline || (language === 'pt' ? 'O que Fazemos' : 'What We Do')}
-          </h3>
-          {data.subtitle && (
-            <p
-              style={{
-                fontFamily: "'Figtree', sans-serif",
-                fontSize: 'clamp(17px, 2vw, 20px)',
-                lineHeight: '1.5',
-                color: 'var(--color-text-secondary)',
-                maxWidth: '60ch',
-                margin: 0,
-              }}
-            >
-              {data.subtitle}
-            </p>
-          )}
+        <FadeIn className="mb-10">
+          <SectionHeading
+            headline={data.headline || (language === 'pt' ? 'O que Fazemos' : 'What We Do')}
+            subtitle={data.subtitle}
+            size="md"
+          />
         </FadeIn>
 
         {preview.length > 0 && (

--- a/src/components/ui/IconButton/IconButton.tsx
+++ b/src/components/ui/IconButton/IconButton.tsx
@@ -4,7 +4,7 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cn } from '../../../lib/cn';
 
 const iconButtonVariants = cva(
-  'inline-flex items-center justify-center rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
+  'inline-flex items-center justify-center rounded-[var(--radius-pill)] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60',
   {
     variants: {
       variant: {

--- a/src/components/ui/LanguageToggle/LanguageToggle.tsx
+++ b/src/components/ui/LanguageToggle/LanguageToggle.tsx
@@ -33,14 +33,14 @@ export function LanguageToggle({ value, onChange, compact = false, className }: 
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          'inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/85 px-4 py-2 text-[#2e3350] shadow-[0_6px_20px_rgba(0,0,0,0.08)] transition hover:bg-white',
+          'inline-flex items-center gap-2 rounded-[var(--radius-pill)] border border-white/40 bg-white/85 px-4 py-2 text-[#2e3350] shadow-[0_6px_20px_rgba(0,0,0,0.08)] transition hover:bg-white',
           compact ? 'h-[44px]' : 'h-[48px]'
         )}
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-label="Selecionar idioma"
       >
-        <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-md bg-[#eef1ff] px-2 text-xs font-bold">
+        <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-[var(--radius-sm)] bg-[#eef1ff] px-2 text-xs font-bold">
           {currentLanguage.flag}
         </span>
         {!compact ? <span className="text-sm font-semibold">{currentLanguage.label}</span> : null}
@@ -50,7 +50,7 @@ export function LanguageToggle({ value, onChange, compact = false, className }: 
       {isOpen ? (
         <div
           role="menu"
-          className="absolute right-0 z-50 mt-2 min-w-[180px] rounded-2xl border border-gray-200 bg-white p-2 shadow-[0_14px_30px_rgba(0,0,0,0.12)]"
+          className="absolute right-0 z-50 mt-2 min-w-[180px] rounded-[var(--radius-md)] border border-gray-200 bg-white p-2 shadow-[0_14px_30px_rgba(0,0,0,0.12)]"
         >
           {languageOptions.map((option) => (
             <button
@@ -63,14 +63,14 @@ export function LanguageToggle({ value, onChange, compact = false, className }: 
                 setIsOpen(false);
               }}
               className={cn(
-                'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition',
+                'flex w-full items-center justify-between rounded-[var(--radius-sm)] px-3 py-2 text-left text-sm transition',
                 option.value === value
                   ? 'bg-[#f3f6ff] font-semibold text-[#2f3a67]'
                   : 'text-[#2e3350] hover:bg-gray-100'
               )}
             >
               <span className="inline-flex items-center gap-2">
-                <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-md bg-[#eef1ff] px-2 text-[11px] font-bold">
+                <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-[var(--radius-sm)] bg-[#eef1ff] px-2 text-[11px] font-bold">
                   {option.flag}
                 </span>
                 {option.label}

--- a/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
+++ b/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
@@ -3,6 +3,7 @@ import { Modal } from '../Modal';
 import { Typography } from '../../ui/Typography';
 import { Play } from 'lucide-react';
 import { useDelayedState } from '../../../hooks/useDelayedState';
+import { cn } from '../../../lib/cn';
 import type { ResolvedYoutubeVideo } from '../../../types/cms';
 
 const mockVideos: ResolvedYoutubeVideo[] = [
@@ -35,30 +36,38 @@ export const YouTubeFeed = ({ videos, showTitle = true }: YouTubeFeedProps) => {
     <>
       {showTitle && <Typography variant="h2" className="mb-8">Vídeos</Typography>}
 
-      {/* Grid de Thumbnails */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          {visibleVideos.map((video) => (
-            <div 
-              key={video.id} 
-              className="group relative cursor-pointer overflow-hidden rounded-[var(--radius-sm)] bg-gray-200 aspect-video"
-              onClick={() => openVideo(video.id)}
-            >
-              {/* Imagem de Capa do Youtube */}
-              <img 
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {visibleVideos.map((video, index) => (
+          <div
+            key={video.id}
+            className={cn(
+              'group cursor-pointer',
+              // Centraliza o último item quando a contagem é ímpar no layout 2-col (sm)
+              visibleVideos.length % 2 !== 0 &&
+                index === visibleVideos.length - 1 &&
+                'sm:col-span-2 sm:max-w-[calc(50%-12px)] sm:mx-auto lg:col-span-1 lg:max-w-full'
+            )}
+            onClick={() => openVideo(video.id)}
+          >
+            <div className="relative overflow-hidden rounded-[var(--radius-sm)] bg-gray-200 aspect-video">
+              <img
                 src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
-                alt={video.title} 
+                alt={video.title}
+                loading="lazy"
                 className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
               />
-              
-              {/* Overlay com botão de Play (Fica visível no hover) */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover:bg-black/40">
                 <div className="rounded-[var(--radius-pill)] bg-[color:var(--color-surface-orange)] p-4 text-[color:var(--color-tag-bg)] shadow-lg transition-transform group-hover:scale-110">
                   <Play fill="currentColor" size={24} />
                 </div>
               </div>
             </div>
-          ))}
-        </div>
+            <p className="mt-2 text-sm font-semibold text-[color:var(--color-text-primary)] line-clamp-2">
+              {video.title}
+            </p>
+          </div>
+        ))}
+      </div>
 
       {/* O Nosso Modal Reutilizável */}
       <Modal 

--- a/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
+++ b/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
@@ -38,22 +38,26 @@ export const YouTubeFeed = ({ videos, showTitle = true }: YouTubeFeedProps) => {
 
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {visibleVideos.map((video, index) => (
-          <div
+          <button
             key={video.id}
+            onClick={() => openVideo(video.id)}
+            aria-label={`Reproduzir: ${video.title}`}
             className={cn(
-              'group cursor-pointer',
-              // Centraliza o último item quando a contagem é ímpar no layout 2-col (sm)
+              'group cursor-pointer border-0 p-0 bg-transparent block w-full text-left',
               visibleVideos.length % 2 !== 0 &&
                 index === visibleVideos.length - 1 &&
                 'sm:col-span-2 sm:max-w-[calc(50%-12px)] sm:mx-auto lg:col-span-1 lg:max-w-full'
             )}
-            onClick={() => openVideo(video.id)}
           >
             <div className="relative overflow-hidden rounded-[var(--radius-sm)] bg-gray-200 aspect-video">
               <img
                 src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
                 alt={video.title}
                 loading="lazy"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).src =
+                    `https://img.youtube.com/vi/${video.id}/hqdefault.jpg`;
+                }}
                 className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
               />
               <div className="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover:bg-black/40">
@@ -65,7 +69,7 @@ export const YouTubeFeed = ({ videos, showTitle = true }: YouTubeFeedProps) => {
             <p className="mt-2 text-sm font-semibold text-[color:var(--color-text-primary)] line-clamp-2">
               {video.title}
             </p>
-          </div>
+          </button>
         ))}
       </div>
 

--- a/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
+++ b/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
@@ -12,9 +12,10 @@ const mockVideos: ResolvedYoutubeVideo[] = [
 
 interface YouTubeFeedProps {
   videos?: ResolvedYoutubeVideo[];
+  showTitle?: boolean;
 }
 
-export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
+export const YouTubeFeed = ({ videos, showTitle = true }: YouTubeFeedProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentVideoId, setCurrentVideoIdNow, setCurrentVideoIdDelayed] = useDelayedState<string | null>(null);
   const visibleVideos = videos && videos.length > 0 ? videos : mockVideos;
@@ -32,10 +33,10 @@ export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
 
   return (
     <>
-      <Typography variant="h2" className="mb-8">Vídeos</Typography>
+      {showTitle && <Typography variant="h2" className="mb-8">Vídeos</Typography>}
 
       {/* Grid de Thumbnails */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           {visibleVideos.map((video) => (
             <div 
               key={video.id} 
@@ -51,7 +52,7 @@ export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
               
               {/* Overlay com botão de Play (Fica visível no hover) */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover:bg-black/40">
-                <div className="rounded-[var(--radius-pill)] bg-red-600 p-4 text-white shadow-lg transition-transform group-hover:scale-110">
+                <div className="rounded-[var(--radius-pill)] bg-[color:var(--color-surface-orange)] p-4 text-[color:var(--color-tag-bg)] shadow-lg transition-transform group-hover:scale-110">
                   <Play fill="currentColor" size={24} />
                 </div>
               </div>

--- a/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
+++ b/src/components/ui/YouTubeFeed/YouTubeFeed.tsx
@@ -39,7 +39,7 @@ export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
           {visibleVideos.map((video) => (
             <div 
               key={video.id} 
-              className="group relative cursor-pointer overflow-hidden rounded-xl bg-gray-200 aspect-video"
+              className="group relative cursor-pointer overflow-hidden rounded-[var(--radius-sm)] bg-gray-200 aspect-video"
               onClick={() => openVideo(video.id)}
             >
               {/* Imagem de Capa do Youtube */}
@@ -51,7 +51,7 @@ export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
               
               {/* Overlay com botão de Play (Fica visível no hover) */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover:bg-black/40">
-                <div className="rounded-full bg-red-600 p-4 text-white shadow-lg transition-transform group-hover:scale-110">
+                <div className="rounded-[var(--radius-pill)] bg-red-600 p-4 text-white shadow-lg transition-transform group-hover:scale-110">
                   <Play fill="currentColor" size={24} />
                 </div>
               </div>
@@ -66,7 +66,7 @@ export const YouTubeFeed = ({ videos }: YouTubeFeedProps) => {
         className="max-w-5xl"
       >
         {/* Usamos 'aspect-video' do Tailwind para manter a proporção 16:9 perfeita em qualquer tamanho de tela */}
-        <div className="aspect-video w-full overflow-hidden rounded-lg bg-black shadow-2xl">
+        <div className="aspect-video w-full overflow-hidden rounded-[var(--radius-sm)] bg-black shadow-2xl">
           {currentVideoId && (
             <iframe
               className="h-full w-full border-0"

--- a/src/features/admin/hooks/useAdminRoute.tsx
+++ b/src/features/admin/hooks/useAdminRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useMatch } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { saveAdminFields } from '../services/cmsAdminService';
 import { ADMIN_ROUTES } from '../config/adminRoutes';
@@ -24,9 +24,11 @@ export function useAdminRoute(
   dirtyFields: Record<string, true>,
   setDirtyFields: React.Dispatch<React.SetStateAction<Record<string, true>>>,
 ) {
-  // Derive activeRouteId from the URL param instead of local state
-  const { routePath } = useParams<{ routePath: string }>();
-  const activeRouteId: AdminRouteId = (ADMIN_ROUTES.find((r) => r.path === routePath)?.id) ?? 'home';
+  // Derive activeRouteId from the current pathname instead of local state.
+  // useMatch (not useParams) because the router declares admin children as literal
+  // paths (no ":routePath" segment) — useParams would always return undefined here.
+  const match = useMatch('/admin/:routePath');
+  const activeRouteId: AdminRouteId = (ADMIN_ROUTES.find((r) => r.path === match?.params.routePath)?.id) ?? 'home';
   const [activeSectionKey, setActiveSectionKey] = useState<string>('pages.home.hero');
 
   const activeRoute = useMemo(

--- a/src/pages/Site.tsx
+++ b/src/pages/Site.tsx
@@ -24,11 +24,11 @@ function Site() {
       <main>
         <StatsSection data={data.stats} />
         <AboutSection data={data.about} />
-        <div className="w-full bg-white pb-12 sm:pb-16">
+        <div className="w-full bg-[color:var(--color-tag-bg)] pb-16 sm:pb-24">
           <div className="mx-auto w-full max-w-[1440px] px-4 sm:px-6 lg:px-10">
             <Link
               to={ROUTES.about}
-              className="text-sm font-semibold text-[color:var(--color-tag-bg)] hover:underline"
+              className="text-sm font-semibold text-[color:var(--color-accent-peach)] hover:text-[color:var(--color-text-cream)] hover:underline"
             >
               {ABOUT_LINK[language] ?? ABOUT_LINK.pt}
             </Link>

--- a/src/pages/Site.tsx
+++ b/src/pages/Site.tsx
@@ -1,4 +1,5 @@
-import { Link, useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router-dom';
+import { SectionCTA } from '../components/composites/SectionCTA/SectionCTA';
 import { HeroSection } from '../components/sections/HeroSection';
 import { AboutSection } from '../components/sections/AboutSection';
 import { CoqueEmAcaoSection } from '../components/sections/CoqueEmAcaoSection';
@@ -10,7 +11,7 @@ import { ROUTES } from '../lib/constants';
 import { useCmsLandingData } from '../hooks/useCmsLandingData';
 import type { PublicLayoutContextValue } from './PublicLayout';
 
-const ABOUT_LINK: Record<string, string> = { pt: 'Conheça nossa história →', en: 'Learn our story →' };
+const ABOUT_LINK: Record<string, string> = { pt: 'Conheça nossa história', en: 'Learn our story' };
 
 function Site() {
   const { language } = useOutletContext<PublicLayoutContextValue>();
@@ -26,12 +27,7 @@ function Site() {
         <AboutSection data={data.about} />
         <div className="w-full bg-[color:var(--color-tag-bg)] pb-16 sm:pb-24">
           <div className="mx-auto w-full max-w-[1440px] px-4 sm:px-6 lg:px-10">
-            <Link
-              to={ROUTES.about}
-              className="text-sm font-semibold text-[color:var(--color-accent-peach)] hover:text-[color:var(--color-text-cream)] hover:underline"
-            >
-              {ABOUT_LINK[language] ?? ABOUT_LINK.pt}
-            </Link>
+            <SectionCTA href={ROUTES.about} label={ABOUT_LINK[language] ?? ABOUT_LINK.pt} tone="on-dark" />
           </div>
         </div>
         <CoqueEmAcaoSection videos={data.youtubeVideos} images={data.carousel.images} language={language} />


### PR DESCRIPTION
## Summary

- **Ritmo cromático**: 6 seções brancas consecutivas viram sequência dark → cinza → laranja → dark; o olho tem onde descansar e onde acelerar
- **Hierarquia visual**: `SectionHeading` component (sm/md/lg + tone on-dark/on-orange) elimina 5 blocos h3 inline idênticos; WaysToHelp (lg) > WhatWeDo (md) > CoqueEmAção/Trust (sm)
- **TrustSection redesign**: fundo escuro, cards glass-dark, outlet como label peach, título como corpo; alinhado ao padrão das demais seções dark
- **Border-radius semântico**: 6 componentes migrados de valores hardcoded (`rounded-full`, `rounded-xl`, `rounded-[50px]`, `rounded-[999px]`) para tokens `--radius-pill / --radius-sm / --radius-md`

## Files changed
- `src/components/composites/SectionHeading.tsx` — novo componente
- `src/components/sections/TrustSection/TrustSection.tsx` — redesign completo
- `src/components/composites/HeaderBar/HeaderBar.tsx` — radius tokens
- `src/components/ui/LanguageToggle/LanguageToggle.tsx` — radius tokens
- `src/components/composites/MobileMenuOverlay/MobileMenuOverlay.tsx` — radius tokens
- `src/components/sections/NewsletterSection/NewsletterSection.tsx` — radius tokens
- `src/components/ui/YouTubeFeed/YouTubeFeed.tsx` — radius tokens
- `src/components/ui/IconButton/IconButton.tsx` — radius tokens
- `src/components/composites/ProjectCard.tsx` — ghost-card → shadow-soft
- `src/pages/Site.tsx` + seções — cores e SectionHeading

## Test plan
- [ ] `tsc --noEmit` limpo (verificado)
- [ ] Visualizar home completa no preview Vercel de staging
- [ ] Conferir ritmo de cores (dark → cinza → laranja → dark → orange newsletter)
- [ ] Conferir hierarquia de títulos entre seções
- [ ] Testar newsletter form (campos pill, botão pill)
- [ ] Testar header mobile: pill container + botão DOE AGORA pill
- [ ] Abrir LanguageToggle e verificar dropdown rounded-md, items rounded-sm