### PR TITLE
feat: campos obrigatórios + ID automático (Projetos e Biblioteca)

### DIFF
--- a/src/features/admin/components/form/AdminInputField.tsx
+++ b/src/features/admin/components/form/AdminInputField.tsx
@@ -2,6 +2,7 @@ import {
   adminFieldLabelClass,
   getAdminInputClass,
 } from '../shared/adminEditorStyles';
+import { cn } from '../../../../lib/cn';
 
 type AdminInputFieldProps = {
   label: string;
@@ -10,6 +11,10 @@ type AdminInputFieldProps = {
   isFieldDirty: (path: Array<string | number>) => boolean;
   onFieldChange: (path: Array<string | number>, value: unknown) => void;
   placeholder?: string;
+  disabled?: boolean;
+  helpText?: string;
+  /** Visual-only: shows a red asterisk and, once the field has been touched, an error state when empty. Does not block saving. */
+  required?: boolean;
 };
 
 export function AdminInputField({
@@ -19,17 +24,36 @@ export function AdminInputField({
   isFieldDirty,
   onFieldChange,
   placeholder,
+  disabled = false,
+  helpText,
+  required = false,
 }: AdminInputFieldProps) {
+  const showRequiredError = required && value.trim() === '';
+
   return (
     <label className="block">
-      <span className={adminFieldLabelClass}>{label}</span>
+      <span className={adminFieldLabelClass}>
+        {label}
+        {required && <span className="ml-0.5 text-rose-500">*</span>}
+      </span>
       <input
         type="text"
         placeholder={placeholder}
         value={value}
+        disabled={disabled}
         onChange={(e) => onFieldChange(path, e.target.value)}
-        className={getAdminInputClass(isFieldDirty(path))}
+        className={cn(
+          getAdminInputClass(isFieldDirty(path)),
+          disabled && 'cursor-not-allowed opacity-60',
+          showRequiredError && 'border-rose-400 focus:border-rose-400 focus:ring-rose-400/20'
+        )}
       />
+      {helpText && !showRequiredError && (
+        <span className="mt-1 block text-xs text-[var(--admin-text-4)]">{helpText}</span>
+      )}
+      {showRequiredError && (
+        <span className="mt-1 block text-xs text-rose-500">Campo obrigatório</span>
+      )}
     </label>
   );
 }

--- a/src/features/admin/routes/media/MediaLibraryRoute.tsx
+++ b/src/features/admin/routes/media/MediaLibraryRoute.tsx
@@ -109,6 +109,10 @@ export function MediaLibraryRoute() {
 
   const handleOptimizeAndSave = async () => {
     if (!selectedFile) return;
+    if (!imageTitle.trim() || !imageAlt.trim()) {
+      toast.error('Preencha o título e o texto alternativo antes de enviar.');
+      return;
+    }
 
     setUploadStatus('optimizing');
     try {
@@ -256,26 +260,44 @@ export function MediaLibraryRoute() {
 
               <div className="space-y-2 border-t border-[var(--admin-border-sub)] pt-2">
                 <label className="block">
-                  <span className="mb-0.5 block text-[10px] font-semibold text-[var(--admin-text-3)]">Título da Imagem</span>
+                  <span className="mb-0.5 block text-[10px] font-semibold text-[var(--admin-text-3)]">
+                    Título da Imagem<span className="ml-0.5 text-rose-500">*</span>
+                  </span>
                   <input
                     type="text"
                     value={imageTitle}
                     onChange={(e) => setImageTitle(e.target.value)}
                     placeholder="Ex: Crianças na horta"
                     disabled={uploadStatus === 'optimizing' || uploadStatus === 'uploading'}
-                    className="h-8 w-full rounded border border-[var(--admin-input-bd)] bg-[var(--admin-input-bg)] px-2 text-xs text-[var(--admin-text-1)] outline-none focus:ring-1 focus:ring-[var(--admin-accent)] disabled:opacity-50"
+                    className={`h-8 w-full rounded border bg-[var(--admin-input-bg)] px-2 text-xs text-[var(--admin-text-1)] outline-none focus:ring-1 disabled:opacity-50 ${
+                      imageTitle.trim() === ''
+                        ? 'border-rose-400 focus:ring-rose-400/40'
+                        : 'border-[var(--admin-input-bd)] focus:ring-[var(--admin-accent)]'
+                    }`}
                   />
+                  {imageTitle.trim() === '' && (
+                    <span className="mt-0.5 block text-[10px] text-rose-500">Campo obrigatório</span>
+                  )}
                 </label>
                 <label className="block">
-                  <span className="mb-0.5 block text-[10px] font-semibold text-[var(--admin-text-3)]">Texto Alternativo (Alt)</span>
+                  <span className="mb-0.5 block text-[10px] font-semibold text-[var(--admin-text-3)]">
+                    Texto Alternativo (Alt)<span className="ml-0.5 text-rose-500">*</span>
+                  </span>
                   <input
                     type="text"
                     value={imageAlt}
                     onChange={(e) => setImageAlt(e.target.value)}
                     placeholder="Descrição para leitores de tela..."
                     disabled={uploadStatus === 'optimizing' || uploadStatus === 'uploading'}
-                    className="h-8 w-full rounded border border-[var(--admin-input-bd)] bg-[var(--admin-input-bg)] px-2 text-xs text-[var(--admin-text-1)] outline-none focus:ring-1 focus:ring-[var(--admin-accent)] disabled:opacity-50"
+                    className={`h-8 w-full rounded border bg-[var(--admin-input-bg)] px-2 text-xs text-[var(--admin-text-1)] outline-none focus:ring-1 disabled:opacity-50 ${
+                      imageAlt.trim() === ''
+                        ? 'border-rose-400 focus:ring-rose-400/40'
+                        : 'border-[var(--admin-input-bd)] focus:ring-[var(--admin-accent)]'
+                    }`}
                   />
+                  {imageAlt.trim() === '' && (
+                    <span className="mt-0.5 block text-[10px] text-rose-500">Campo obrigatório</span>
+                  )}
                 </label>
               </div>
             </div>
@@ -322,7 +344,7 @@ export function MediaLibraryRoute() {
           {selectedFile && (
             <button
               type="button"
-              disabled={uploadStatus === 'optimizing' || uploadStatus === 'uploading'}
+              disabled={uploadStatus === 'optimizing' || uploadStatus === 'uploading' || !imageTitle.trim() || !imageAlt.trim()}
               onClick={handleOptimizeAndSave}
               className="w-full rounded bg-[var(--admin-accent)] px-3 py-2 text-sm font-semibold text-white hover:opacity-90 disabled:opacity-50 shadow-sm transition-all"
             >

--- a/src/features/admin/routes/projects/editors/ProjectsEditor.tsx
+++ b/src/features/admin/routes/projects/editors/ProjectsEditor.tsx
@@ -11,6 +11,7 @@ import { CollapsibleItem } from '../../../components/shared/CollapsibleItem';
 import { AdminPreviewPanel } from '../../../components/shared/AdminPreviewPanel';
 import { ProjectsSection } from '../../../../../components/sections/ProjectsSection';
 import { pickLang } from '../../../../../services/cmsService';
+import { slugify, uniqueSlug } from '../../../utils/slugify';
 import type { CmsLanguage, ResolvedProject } from '../../../../../types/cms';
 
 type I18nField = { pt?: string; en?: string };
@@ -55,6 +56,18 @@ export function ProjectsEditor({ data, isFieldDirty, onFieldChange, onAddArrayIt
   const [previewLang, setPreviewLang] = useState<CmsLanguage>('pt');
   const items = Array.isArray(data?.items) ? data.items : [];
 
+  // O ID não é editável diretamente — equipe não-técnica não sabe o que colocar
+  // ali. Ele é derivado do Título (PT) a cada alteração, então nunca fica
+  // dessincronizado do conteúdo que representa.
+  const handleTitlePtChange = (index: number, value: string) => {
+    onFieldChange(['items', index, 'title', 'pt'], value);
+    const siblingIds = items
+      .filter((_, i) => i !== index)
+      .map((p) => p.id ?? '')
+      .filter(Boolean);
+    onFieldChange(['items', index, 'id'], uniqueSlug(slugify(value), siblingIds));
+  };
+
   return (
     <div className="space-y-4">
       {items.length === 0 && (
@@ -62,7 +75,7 @@ export function ProjectsEditor({ data, isFieldDirty, onFieldChange, onAddArrayIt
       )}
       {items.map((project, index) => (
         <CollapsibleItem
-          key={project.id ?? index}
+          key={index}
           label={`Projeto ${index + 1}`}
           summary={project.title?.pt || ''}
           onRemove={() => onRemoveArrayItem(['items'], index)}
@@ -70,22 +83,18 @@ export function ProjectsEditor({ data, isFieldDirty, onFieldChange, onAddArrayIt
           onMoveUp={index > 0 ? () => onMoveArrayItem(['items'], index, 'up') : undefined}
           onMoveDown={index < items.length - 1 ? () => onMoveArrayItem(['items'], index, 'down') : undefined}
         >
-          {/* Global fields */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <AdminInputField label="ID" path={['items', index, 'id']} value={project.id ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
-            <AdminInputField label="Localização" path={['items', index, 'location']} value={project.location ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
-            <div className="col-span-full">
-              <AdminInputField label="URL da ação (actionHref)" path={['items', index, 'actionHref']} value={project.actionHref ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
-            </div>
-          </div>
-
-          {renderImageField(project.image ?? '', ['items', index, 'image'], 'Imagem do projeto', '/placeholder-image.png')}
-
           {/* i18n fields */}
           <div className={adminPanelGridClass}>
             {(['pt', 'en'] as const).map((lang) => (
               <AdminEditorCard key={lang} title={lang === 'pt' ? 'Português (PT)' : 'Inglês (EN)'}>
-                <AdminInputField label="Título" path={['items', index, 'title', lang]} value={project.title?.[lang] ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+                <AdminInputField
+                  label="Título"
+                  required
+                  path={['items', index, 'title', lang]}
+                  value={project.title?.[lang] ?? ''}
+                  isFieldDirty={isFieldDirty}
+                  onFieldChange={lang === 'pt' ? (_path, value) => handleTitlePtChange(index, value as string) : onFieldChange}
+                />
                 <div className="block">
                   <span className={adminFieldLabelClass}>Descrição (Markdown)</span>
                   <RichTextEditor
@@ -99,6 +108,24 @@ export function ProjectsEditor({ data, isFieldDirty, onFieldChange, onAddArrayIt
               </AdminEditorCard>
             ))}
           </div>
+
+          <AdminInputField label="URL da ação (actionHref)" path={['items', index, 'actionHref']} value={project.actionHref ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+
+          {/* Global fields */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <AdminInputField
+              label="ID"
+              disabled
+              helpText="Gerado automaticamente a partir do Título (PT)"
+              path={['items', index, 'id']}
+              value={project.id ?? ''}
+              isFieldDirty={isFieldDirty}
+              onFieldChange={onFieldChange}
+            />
+            <AdminInputField label="Localização" path={['items', index, 'location']} value={project.location ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+          </div>
+
+          {renderImageField(project.image ?? '', ['items', index, 'image'], 'Imagem do projeto', '/placeholder-image.png')}
         </CollapsibleItem>
       ))}
       <AdminAddButton onClick={() => onAddArrayItem(['items'])}>Adicionar projeto</AdminAddButton>

--- a/src/features/admin/utils/slugify.ts
+++ b/src/features/admin/utils/slugify.ts
@@ -1,0 +1,17 @@
+export function slugify(input: string): string {
+  return input
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Appends -2, -3... if `base` collides with an id already in use by a sibling item. */
+export function uniqueSlug(base: string, existingIds: string[]): string {
+  if (!base || !existingIds.includes(base)) return base;
+  let suffix = 2;
+  while (existingIds.includes(`${base}-${suffix}`)) suffix++;
+  return `${base}-${suffix}`;
+}


### PR DESCRIPTION
## Summary
Equipe não-técnica estava confusa com o campo ID livre em "Nossos Projetos" e enviava imagens na Biblioteca sem título/alt.

**Projetos** (visual apenas, não bloqueia Salvar — mesmo padrão do resto do admin):
- ID vira campo travado, gerado automaticamente a partir do Título (PT): sem acentos, espaços viram hífen. Colisão (ex: usar "Duplicar") resolve sozinha com sufixo `-2`, `-3`...
- Título (PT e EN) marcado como obrigatório: asterisco + borda vermelha + "Campo obrigatório" quando vazio
- Campos reordenados: PT/EN → URL da ação → ID + Localização → foto

**Biblioteca — Enviar Nova Imagem** (bloqueia o botão de salvar — já era o padrão existente aqui para Categoria, e o clique salva na hora, sem rascunho descartável):
- Título e Texto Alternativo (Alt) obrigatórios para habilitar "Otimizar e Salvar Imagem"

## Test plan
- [x] `tsc --noEmit` limpo
- [x] `npm run build` limpo
- [x] Verificado ao vivo no admin autenticado: ID auto-gerado em tempo real, painel não colapsa mais ao digitar (bug que apareceu e foi corrigido no processo), aviso obrigatório PT+EN funcionando
- [x] Verificado ao vivo na Biblioteca: botão "Otimizar e Salvar Imagem" desabilitado até título+alt preenchidos, testado via seleção de arquivo simulada (sem upload real)