### PR TITLE
feat: arquivar projetos + links externos abrem em nova aba

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,14 +58,10 @@ Comandos CLI completos:
 git fetch origin
 git switch -c feature/nome-da-feature origin/staging
 
-# Abrir PR → staging
-gh pr create --base staging --title "feat: descrição"
+# … commitar normalmente …
 
-# Mergear em staging + deletar branch (sem proteção, roda imediatamente)
-gh pr merge --squash --delete-branch
-
-# Após validar em staging.coqueconnecta.ong.br, abrir PR → main
-gh pr create --base main --title "feat: descrição"
+# Promover: abre PR → staging (squash + deleta branch) e PR → main de uma vez
+./scripts/promote.sh "feat: descrição" "## Summary\n- o que mudou"
 
 # Após aprovação no GitHub, mergear em main — merge normal, NUNCA squash (ver nota abaixo)
 gh pr merge --merge

--- a/README.md
+++ b/README.md
@@ -61,32 +61,35 @@ npm run dev
 - `staging` → homologação. Push gera preview automático na Vercel.
 - `feature/*` ou `fix/*` → branches de trabalho, criadas a partir de `origin/staging`.
 
-Fluxo completo via CLI:
+Fluxo via script (caminho padrão):
 
 ```bash
-# 1. Criar branch a partir de origin/staging (evita divergência ao abrir PR)
+# 1. Criar branch a partir de origin/staging
 git fetch origin
 git switch -c feature/nome-da-feature origin/staging
 
 # 2. Trabalhar, commitar normalmente
 
-# 3. Abrir PR → staging
-gh pr create --base staging --title "feat: descrição"
+# 3. Promover: abre PR → staging, mergeia, deleta branch e abre PR → main
+./scripts/promote.sh "feat: descrição" "## Summary\n- o que mudou"
 
-# 4. Mergear em staging e deletar a branch (staging não tem proteção)
-gh pr merge --squash --delete-branch
+# 4. Validar em staging.coqueconnecta.ong.br
 
-# 5. Validar em staging.coqueconnecta.ong.br
-
-# 6. Abrir PR → main (requer aprovação na UI do GitHub)
-gh pr create --base main --title "feat: descrição"
-
-# 7. Após aprovação, mergear em main
-gh pr merge --squash --delete-branch
+# 5. Aprovar e mergear o PR staging → main na UI do GitHub
 ```
 
-> `--squash` condensa os commits da branch em um único commit limpo no histórico.
-> `--delete-branch` remove a branch local e remota automaticamente após o merge.
+Fluxo manual (referência):
+
+```bash
+gh pr create --base staging --title "feat: descrição"
+gh pr merge --squash --delete-branch   # feature → staging
+git checkout staging && git pull origin staging
+gh pr create --base main --title "feat: descrição"
+gh pr merge --merge                    # staging → main (NUNCA --squash, veja nota abaixo)
+```
+
+> **Importante:** o merge de `staging → main` deve ser sempre `--merge`, nunca `--squash`. Squash cria um SHA diferente e quebra a ancestralidade, gerando conflitos fantasma em todas as promoções seguintes. Ver nota completa em `CLAUDE.md`.
+> `--delete-branch` só se usa no merge de feature → staging. A `staging` é permanente — nunca deletar.
 ## Deploy
 
 O projeto é deployado pela **Vercel** (conta `coqueconnecta@gmail.com`).

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fluxo completo de promoção de feature branch para produção.
+#
+# Uso:
+#   ./scripts/promote.sh "feat: título" "## Summary\n- item 1"
+#
+# Argumentos:
+#   $1  Título do PR (obrigatório)
+#   $2  Body do PR   (opcional — omitir abre sem descrição)
+#
+# O que faz:
+#   1. Abre PR da branch atual → staging
+#   2. Mergeia com squash e deleta a branch
+#   3. Atualiza staging local
+#   4. Abre PR staging → main (aguarda aprovação humana)
+
+set -euo pipefail
+
+TITLE="${1:?Uso: $0 \"feat: título\" [\"body\"]}"
+BODY="${2:-}"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$BRANCH" == "staging" || "$BRANCH" == "main" ]]; then
+  echo "Erro: rode este script a partir de uma feature branch, não de '$BRANCH'." >&2
+  exit 1
+fi
+
+echo "▶ branch atual: $BRANCH"
+
+echo ""
+echo "── 1/4  Criando PR: $BRANCH → staging ──────────────────────"
+if [[ -n "$BODY" ]]; then
+  gh pr create --base staging --title "$TITLE" --body "$BODY"
+else
+  gh pr create --base staging --title "$TITLE" --body ""
+fi
+
+echo ""
+echo "── 2/4  Mergeando (squash) e deletando branch ───────────────"
+gh pr merge --squash --delete-branch
+
+echo ""
+echo "── 3/4  Atualizando staging local ───────────────────────────"
+git checkout staging
+git pull origin staging
+
+echo ""
+echo "── 4/4  Criando PR: staging → main ──────────────────────────"
+if [[ -n "$BODY" ]]; then
+  gh pr create --base main --title "$TITLE" --body "$BODY"
+else
+  gh pr create --base main --title "$TITLE" --body ""
+fi
+
+echo ""
+echo "✓ Concluído. Aguardando aprovação no GitHub para staging → main."

--- a/src/components/composites/ProjectCard.tsx
+++ b/src/components/composites/ProjectCard.tsx
@@ -56,6 +56,10 @@ export function ProjectCard({ project }: ProjectCardProps) {
               href={project.actionHref || '#'}
               variant="primary"
               className="h-9 px-6 py-2 text-[11px] font-bold tracking-wider"
+              {...(/^https?:\/\//.test(project.actionHref ?? '') && {
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              })}
             >
               {project.actionLabel || 'Saiba mais'}
             </Button>

--- a/src/features/admin/components/shared/CollapsibleItem.tsx
+++ b/src/features/admin/components/shared/CollapsibleItem.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, ChevronDown, ChevronUp, Copy, Trash2 } from 'lucide-react';
+import { Archive, ArchiveRestore, ArrowDown, ArrowUp, ChevronDown, ChevronUp, Copy, Trash2 } from 'lucide-react';
 import { useDisclosure } from '../../hooks/useDisclosure';
 
 type CollapsibleItemProps = {
@@ -8,11 +8,13 @@ type CollapsibleItemProps = {
   onDuplicate?: () => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  onArchive?: () => void;
+  isArchived?: boolean;
   children: React.ReactNode;
   defaultOpen?: boolean;
 };
 
-export function CollapsibleItem({ label, summary, onRemove, onDuplicate, onMoveUp, onMoveDown, children, defaultOpen = false }: CollapsibleItemProps) {
+export function CollapsibleItem({ label, summary, onRemove, onDuplicate, onMoveUp, onMoveDown, onArchive, isArchived = false, children, defaultOpen = false }: CollapsibleItemProps) {
   const { isOpen: open, toggle } = useDisclosure(defaultOpen);
   return (
     <div className="rounded-md border border-[var(--admin-border-sub)] bg-[var(--admin-surface)] shadow-sm overflow-hidden">
@@ -58,6 +60,18 @@ export function CollapsibleItem({ label, summary, onRemove, onDuplicate, onMoveU
             className="text-[var(--admin-text-4)] hover:text-[var(--admin-text-1)] transition-colors shrink-0"
           >
             <Copy className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {onArchive && (
+          <button
+            type="button"
+            onClick={onArchive}
+            aria-label={isArchived ? 'Reativar projeto' : 'Arquivar projeto'}
+            className="text-amber-400 hover:text-amber-600 transition-colors shrink-0"
+          >
+            {isArchived
+              ? <ArchiveRestore className="h-3.5 w-3.5" />
+              : <Archive className="h-3.5 w-3.5" />}
           </button>
         )}
         <button

--- a/src/features/admin/routes/projects/editors/ProjectsEditor.tsx
+++ b/src/features/admin/routes/projects/editors/ProjectsEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { AdminEditorCard } from '../../../components/shared/AdminEditorCard';
 import {
   adminFieldLabelClass,
@@ -12,6 +13,7 @@ import { AdminPreviewPanel } from '../../../components/shared/AdminPreviewPanel'
 import { ProjectsSection } from '../../../../../components/sections/ProjectsSection';
 import { pickLang } from '../../../../../services/cmsService';
 import { slugify, uniqueSlug } from '../../../utils/slugify';
+import { useDisclosure } from '../../../hooks/useDisclosure';
 import type { CmsLanguage, ResolvedProject } from '../../../../../types/cms';
 
 type I18nField = { pt?: string; en?: string };
@@ -21,6 +23,7 @@ type Project = {
   image?: string;
   location?: string;
   actionHref?: string;
+  archived?: boolean;
   title?: I18nField;
   bodyMd?: I18nField;
   actionLabel?: I18nField;
@@ -41,94 +44,133 @@ type ProjectsEditorProps = {
 function resolvePreviewData(data: ProjectsEditorProps['data'], language: CmsLanguage): ResolvedProject[] {
   const toI18nField = (field?: I18nField): { pt: string; en: string } => ({ pt: field?.pt ?? '', en: field?.en ?? '' });
 
-  return (data.items ?? []).map((project) => ({
-    id: project.id ?? '',
-    image: project.image ?? '',
-    location: project.location ?? '',
-    actionHref: project.actionHref,
-    title: pickLang(toI18nField(project.title), language),
-    bodyMd: pickLang(toI18nField(project.bodyMd), language),
-    actionLabel: pickLang(toI18nField(project.actionLabel), language),
-  }));
+  return (data.items ?? [])
+    .filter((project) => !project.archived)
+    .map((project) => ({
+      id: project.id ?? '',
+      image: project.image ?? '',
+      location: project.location ?? '',
+      actionHref: project.actionHref,
+      title: pickLang(toI18nField(project.title), language),
+      bodyMd: pickLang(toI18nField(project.bodyMd), language),
+      actionLabel: pickLang(toI18nField(project.actionLabel), language),
+    }));
 }
 
 export function ProjectsEditor({ data, isFieldDirty, onFieldChange, onAddArrayItem, onRemoveArrayItem, onMoveArrayItem, onDuplicateArrayItem, renderImageField }: ProjectsEditorProps) {
   const [previewLang, setPreviewLang] = useState<CmsLanguage>('pt');
+  const { isOpen: archivedOpen, toggle: toggleArchived } = useDisclosure(false);
   const items = Array.isArray(data?.items) ? data.items : [];
 
-  // O ID não é editável diretamente — equipe não-técnica não sabe o que colocar
-  // ali. Ele é derivado do Título (PT) a cada alteração, então nunca fica
-  // dessincronizado do conteúdo que representa.
-  const handleTitlePtChange = (index: number, value: string) => {
-    onFieldChange(['items', index, 'title', 'pt'], value);
+  const itemsWithIndex = items.map((p, i) => ({ ...p, _idx: i }));
+  const activeItems = itemsWithIndex.filter((p) => !p.archived);
+  const archivedItems = itemsWithIndex.filter((p) => p.archived);
+
+  const handleTitlePtChange = (originalIndex: number, value: string) => {
+    onFieldChange(['items', originalIndex, 'title', 'pt'], value);
     const siblingIds = items
-      .filter((_, i) => i !== index)
+      .filter((_, i) => i !== originalIndex)
       .map((p) => p.id ?? '')
       .filter(Boolean);
-    onFieldChange(['items', index, 'id'], uniqueSlug(slugify(value), siblingIds));
+    onFieldChange(['items', originalIndex, 'id'], uniqueSlug(slugify(value), siblingIds));
+  };
+
+  const renderProjectItem = (project: Project & { _idx: number }, withinActive: boolean) => {
+    const idx = project._idx;
+    const prevIsActive = idx > 0 && !items[idx - 1]?.archived;
+    const nextIsActive = idx < items.length - 1 && !items[idx + 1]?.archived;
+
+    return (
+      <CollapsibleItem
+        key={idx}
+        label={`Projeto ${idx + 1}`}
+        summary={project.title?.pt || ''}
+        onRemove={() => onRemoveArrayItem(['items'], idx)}
+        onDuplicate={withinActive ? () => onDuplicateArrayItem(['items'], idx) : undefined}
+        onMoveUp={withinActive && prevIsActive ? () => onMoveArrayItem(['items'], idx, 'up') : undefined}
+        onMoveDown={withinActive && nextIsActive ? () => onMoveArrayItem(['items'], idx, 'down') : undefined}
+        onArchive={() => onFieldChange(['items', idx, 'archived'], !project.archived)}
+        isArchived={!!project.archived}
+      >
+        {/* i18n fields */}
+        <div className={adminPanelGridClass}>
+          {(['pt', 'en'] as const).map((lang) => (
+            <AdminEditorCard key={lang} title={lang === 'pt' ? 'Português (PT)' : 'Inglês (EN)'}>
+              <AdminInputField
+                label="Título"
+                required
+                path={['items', idx, 'title', lang]}
+                value={project.title?.[lang] ?? ''}
+                isFieldDirty={isFieldDirty}
+                onFieldChange={lang === 'pt' ? (_path, value) => handleTitlePtChange(idx, value as string) : onFieldChange}
+              />
+              <div className="block">
+                <span className={adminFieldLabelClass}>Descrição (Markdown)</span>
+                <RichTextEditor
+                  value={project.bodyMd?.[lang] ?? ''}
+                  onChange={(md) => onFieldChange(['items', idx, 'bodyMd', lang], md)}
+                  isDirty={isFieldDirty(['items', idx, 'bodyMd', lang])}
+                  ariaLabel={`Descrição (${lang.toUpperCase()})`}
+                />
+              </div>
+              <AdminInputField label="Botão de ação" path={['items', idx, 'actionLabel', lang]} value={project.actionLabel?.[lang] ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+            </AdminEditorCard>
+          ))}
+        </div>
+
+        <AdminInputField label="URL da ação (actionHref)" path={['items', idx, 'actionHref']} value={project.actionHref ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+
+        {/* Global fields */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <AdminInputField
+            label="ID"
+            disabled
+            helpText="Gerado automaticamente a partir do Título (PT)"
+            path={['items', idx, 'id']}
+            value={project.id ?? ''}
+            isFieldDirty={isFieldDirty}
+            onFieldChange={onFieldChange}
+          />
+          <AdminInputField label="Localização" path={['items', idx, 'location']} value={project.location ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+        </div>
+
+        {renderImageField(project.image ?? '', ['items', idx, 'image'], 'Imagem do projeto', '/placeholder-image.png')}
+      </CollapsibleItem>
+    );
   };
 
   return (
     <div className="space-y-4">
-      {items.length === 0 && (
+      {activeItems.length === 0 && archivedItems.length === 0 && (
         <p className="text-sm text-[var(--admin-text-4)] py-2">Nenhum projeto adicionado ainda.</p>
       )}
-      {items.map((project, index) => (
-        <CollapsibleItem
-          key={index}
-          label={`Projeto ${index + 1}`}
-          summary={project.title?.pt || ''}
-          onRemove={() => onRemoveArrayItem(['items'], index)}
-          onDuplicate={() => onDuplicateArrayItem(['items'], index)}
-          onMoveUp={index > 0 ? () => onMoveArrayItem(['items'], index, 'up') : undefined}
-          onMoveDown={index < items.length - 1 ? () => onMoveArrayItem(['items'], index, 'down') : undefined}
-        >
-          {/* i18n fields */}
-          <div className={adminPanelGridClass}>
-            {(['pt', 'en'] as const).map((lang) => (
-              <AdminEditorCard key={lang} title={lang === 'pt' ? 'Português (PT)' : 'Inglês (EN)'}>
-                <AdminInputField
-                  label="Título"
-                  required
-                  path={['items', index, 'title', lang]}
-                  value={project.title?.[lang] ?? ''}
-                  isFieldDirty={isFieldDirty}
-                  onFieldChange={lang === 'pt' ? (_path, value) => handleTitlePtChange(index, value as string) : onFieldChange}
-                />
-                <div className="block">
-                  <span className={adminFieldLabelClass}>Descrição (Markdown)</span>
-                  <RichTextEditor
-                    value={project.bodyMd?.[lang] ?? ''}
-                    onChange={(md) => onFieldChange(['items', index, 'bodyMd', lang], md)}
-                    isDirty={isFieldDirty(['items', index, 'bodyMd', lang])}
-                    ariaLabel={`Descrição (${lang.toUpperCase()})`}
-                  />
-                </div>
-                <AdminInputField label="Botão de ação" path={['items', index, 'actionLabel', lang]} value={project.actionLabel?.[lang] ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
-              </AdminEditorCard>
-            ))}
-          </div>
 
-          <AdminInputField label="URL da ação (actionHref)" path={['items', index, 'actionHref']} value={project.actionHref ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
+      {activeItems.map((project) => renderProjectItem(project, true))}
 
-          {/* Global fields */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <AdminInputField
-              label="ID"
-              disabled
-              helpText="Gerado automaticamente a partir do Título (PT)"
-              path={['items', index, 'id']}
-              value={project.id ?? ''}
-              isFieldDirty={isFieldDirty}
-              onFieldChange={onFieldChange}
-            />
-            <AdminInputField label="Localização" path={['items', index, 'location']} value={project.location ?? ''} isFieldDirty={isFieldDirty} onFieldChange={onFieldChange} />
-          </div>
-
-          {renderImageField(project.image ?? '', ['items', index, 'image'], 'Imagem do projeto', '/placeholder-image.png')}
-        </CollapsibleItem>
-      ))}
       <AdminAddButton onClick={() => onAddArrayItem(['items'])}>Adicionar projeto</AdminAddButton>
+
+      {/* Archived section */}
+      {archivedItems.length > 0 && (
+        <div className="rounded-md border border-amber-900/30 bg-amber-950/10 overflow-hidden">
+          <button
+            type="button"
+            onClick={toggleArchived}
+            className="flex items-center gap-2 w-full px-4 py-2.5 text-left"
+          >
+            {archivedOpen
+              ? <ChevronUp className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+              : <ChevronDown className="h-3.5 w-3.5 text-amber-500 shrink-0" />}
+            <span className="text-xs font-semibold uppercase tracking-wider text-amber-500">
+              Arquivados ({archivedItems.length})
+            </span>
+          </button>
+          {archivedOpen && (
+            <div className="border-t border-amber-900/30 px-4 pt-4 pb-4 space-y-4">
+              {archivedItems.map((project) => renderProjectItem(project, false))}
+            </div>
+          )}
+        </div>
+      )}
 
       <AdminPreviewPanel language={previewLang} onLanguageChange={setPreviewLang}>
         <ProjectsSection projects={resolvePreviewData(data, previewLang)} language={previewLang} />

--- a/src/services/cmsService.ts
+++ b/src/services/cmsService.ts
@@ -202,7 +202,7 @@ export async function getCmsWhatWeDoData(language: CmsLanguage): Promise<Resolve
 export async function getCmsProjectsData(language: CmsLanguage): Promise<ResolvedProject[]> {
   const data = await fetchNode<CmsProjectsData>(`${V3}/pages/projects`);
   if (!data?.items) return [];
-  return data.items.map((p) => ({
+  return data.items.filter((p) => !p.archived).map((p) => ({
     id:          p.id,
     image:       p.image,
     location:    p.location,

--- a/src/types/cms.ts
+++ b/src/types/cms.ts
@@ -147,6 +147,7 @@ export interface CmsProject {
   image: string;
   location: string;
   actionHref?: string;
+  archived?: boolean;
   title: I18nField;
   bodyMd: I18nField;
   actionLabel: I18nField;


### PR DESCRIPTION
## Summary
- Botão Archive/ArchiveRestore por projeto no admin; seção "Arquivados (N)" colapsável em âmbar
- Site público e pré-visualização filtram automaticamente projetos arquivados
- `actionHref` externo (`http(s)://`) abre em nova aba no `ProjectCard`

## Test plan
- [ ] Arquivar um projeto → sai da lista ativa, aparece em "Arquivados"
- [ ] Restaurar projeto → volta para lista ativa, seção some se vazia
- [ ] Salvar página → campo `archived` persiste no Firebase
- [ ] Site público não exibe projetos arquivados
- [ ] Link externo abre em nova aba; link interno (`/rota`) na mesma aba