### PR TITLE
docs: atualizar documentacao de contexto com informacoes do blog e tradutor

### DIFF
--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -22,7 +22,7 @@ O projeto é o site institucional da ONG Coque Connecta, com:
 - área pública em React + Vite;
 - conteúdo gerenciado via Firebase Realtime Database em `cms/v3`;
 - painel `/admin` protegido por autenticação Firebase;
-- páginas públicas: Home, Nossos Projetos, Privacidade e Transparência.
+- páginas públicas: Home, Nossos Projetos, Privacidade, Transparência e Blog.
 
 ## Stack atual
 
@@ -51,8 +51,10 @@ Rotas públicas:
 - `/` -> Home
 - `/privacidade` -> página de privacidade
 - `/transparencia` -> página de transparência
-- `*` -> fallback 404 dentro do layout público
 - `/nossos-projetos` -> página de projetos
+- `/blog` -> listagem de posts do blog
+- `/blog/:slug` -> visualização de um post do blog
+- `*` -> fallback 404 dentro do layout público
 
 Rotas internas:
 
@@ -100,6 +102,7 @@ Fonte de verdade atual de conteúdo (`cms/v3`):
 - `cms/v3/pages/projects/items` — array único com campos globais e i18n inline
 - `cms/v3/pages/privacy`
 - `cms/v3/pages/transparency`
+- `cms/v3/blog/posts` — coleção de postagens do blog estruturadas em Markdown e i18n inline
 
 Convenção v3 de i18n por campo:
 
@@ -143,6 +146,7 @@ Rotas do admin:
 - Privacy
 - Transparency
 - Configurações Globais (nav, footer, newsletter)
+- Blog (gerenciamento de posts com Tiptap + Tradução automática PT/EN)
 
 Base técnica do admin:
 
@@ -152,9 +156,10 @@ Base técnica do admin:
 - `src/features/admin/hooks/useAdminRoute.tsx` — motor de salvamento; payload sempre escreve no path do campo diretamente (sem distinção "global" vs "local")
 - `src/features/admin/hooks/useAdminData.ts` — carrega `cms/v3/shared` e `cms/v3/pages` em `Promise.all`
 - `src/features/admin/hooks/useDirtyFields.ts` — rastreamento de campos alterados
-- `src/features/admin/routes/` — organização por rota pública (`home/`, `projects/`, `privacy/`, `transparency/`, `settings/`)
+- `src/features/admin/routes/` — organização por rota pública (`home/`, `projects/`, `privacy/`, `transparency/`, `settings/`, `blog/`)
 - `src/features/admin/shared/` — componentes de formulário reutilizáveis (`ImageField`, `AdminEditorCard`, etc.)
 - `src/features/admin/layout/` — casca do painel (`AdminLayout`, `AdminPageHeader`)
+- `src/services/translationService.ts` — serviço de tradução automática PT-EN usando MyMemory com concorrência limitada (limite 3) e preservação de Markdown
 
 Comportamento atual do admin:
 
@@ -193,7 +198,7 @@ src/
   components/
     composites/      # ProjectCard, ProjectGrid, etc.
     icons/
-    sections/        # Seções públicas (Hero, About, etc.)
+    sections/        # Seções públicas (Hero, About, BlogTeaserSection, etc.)
     ui/              # Átomos: Button, FadeIn, Modal, etc.
   data/
   features/
@@ -208,12 +213,13 @@ src/
           editors/   # ProjectsEditor
         privacy/
         transparency/
+        blog/        # BlogRoute.tsx (CRUD de posts)
       shared/        # Componentes de formulário reutilizáveis
       types.ts
       utils/
   hooks/             # useCmsLandingData, useCmsProjectsData
-  pages/
-  services/
+  pages/             # BlogPage.tsx, BlogPostPage.tsx
+  services/          # blogService.ts, translationService.ts
   types/
 docs/
   project-context.md

--- a/refactor-context.md
+++ b/refactor-context.md
@@ -41,12 +41,21 @@ Documentos historicos:
 - Documentacao sincronizada com estado atual; `docs/backlog.md` e issue template de imagens atualizados.
 - Config Firebase migrada para variaveis de ambiente (`import.meta.env.VITE_*`); Vercel configurada com todas as envs.
 
-## Pendencias imediatas
+## Delta recente (ago/2026)
 
-- Configurar protecao de branch `main` no GitHub com a conta `coqueconnecta@gmail.com`:
-  Settings → Branches → Add rule → `main` → "Require a pull request before merging" (1 approval).
+- Criado sistema de Blog Interno completo e nativo:
+  - Serviço Firebase RTDB `src/services/blogService.ts` sob o nó `cms/v3/blog/posts`.
+  - Página de CRUD administrativo no painel em `src/features/admin/routes/blog/BlogRoute.tsx` com editor Tiptap (Markdown) e integração à biblioteca de mídias existente.
+  - Páginas públicas `/blog` (listagem com skeletons e cards responsivos) e `/blog/:slug` (detalhes renderizando Markdown e contendo CTA de doação).
+  - Componente de destaque `<BlogTeaserSection />` integrado no rodapé da Home.
+  - Regras de segurança do Firebase atualizadas no `database.rules.json` para o nó `cms/v3/blog` (leitura pública, escrita autenticada) e deployado via CLI.
+- Implementada funcionalidade de Tradução Automática no editor de postagens do Admin:
+  - Serviço `src/services/translationService.ts` integrando com a API MyMemory.
+  - Divisão de conteúdo Markdown em parágrafos e processamento paralelo controlado (limite de 3 requisições simultâneas para evitar rate limit) preservando elementos estruturais (listas, títulos e imagens).
+  - Botão de acionamento dinâmico na aba "English" com overlay de progresso (0-100%) e bloqueio de tela temporário.
 
 ## Proximo passo objetivo
 
-- Iniciar novas features via branches `feature/*` abertas a partir de `origin/staging`, com PR → staging → main.
+- Validar a branch `staging` com as novas features de Blog e Tradução Automática na Vercel.
+- Abrir Pull Request de `staging` -> `main` para promover as alterações para o ambiente de produção.
 - Manter `docs/project-context.md` como fonte de verdade tecnica apos mudancas estruturais.


### PR DESCRIPTION
Atualizacao dos arquivos project-context.md e refactor-context.md para registrar a nova arquitetura do Blog e o servico de traducao automatica PT-EN.