### PR TITLE
fix: fatiar paragrafos longos de traducao

### DIFF
--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -53,11 +53,63 @@ async function limitConcurrency<T, R>(
 }
 
 /**
+ * Splits a long text into smaller sentences/chunks of at most `maxLength` characters.
+ * This preserves sentence boundaries for better translation quality.
+ */
+function splitIntoChunks(text: string, maxLength = 400): string[] {
+  if (text.length <= maxLength) return [text];
+
+  // Match sentences ending in punctuation (. ! ?)
+  const sentences = text.match(/[^.!?]+[.!?]+(\s+|$)/g) || [text];
+  const chunks: string[] = [];
+  let currentChunk = '';
+
+  for (const sentence of sentences) {
+    if ((currentChunk + sentence).length <= maxLength) {
+      currentChunk += sentence;
+    } else {
+      if (currentChunk.trim()) {
+        chunks.push(currentChunk.trim());
+      }
+      
+      if (sentence.length > maxLength) {
+        // If a single sentence is longer than maxLength, split it by words
+        let remaining = sentence;
+        while (remaining.length > maxLength) {
+          let slicePoint = remaining.lastIndexOf(' ', maxLength);
+          if (slicePoint <= 0) slicePoint = maxLength;
+          chunks.push(remaining.substring(0, slicePoint).trim());
+          remaining = remaining.substring(slicePoint);
+        }
+        currentChunk = remaining;
+      } else {
+        currentChunk = sentence;
+      }
+    }
+  }
+
+  if (currentChunk.trim()) {
+    chunks.push(currentChunk.trim());
+  }
+
+  return chunks;
+}
+
+/**
  * Translates a plain text string from Portuguese to English using MyMemory API.
+ * Automatically splits texts longer than 400 characters to prevent API size limit errors.
  */
 export async function translateText(text: string): Promise<string> {
   const trimmed = text.trim();
   if (!trimmed) return '';
+
+  // Safe limit of 400 characters to prevent MyMemory API query limits
+  if (trimmed.length > 400) {
+    const chunks = splitIntoChunks(trimmed, 400);
+    // Translate chunks in parallel
+    const translatedChunks = await Promise.all(chunks.map((chunk) => translateText(chunk)));
+    return translatedChunks.join(' ');
+  }
 
   // MyMemory API GET request
   const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(trimmed)}&langpair=pt|en`;
@@ -68,8 +120,18 @@ export async function translateText(text: string): Promise<string> {
   }
 
   const data = await response.json();
-  if (data.responseData?.translatedText) {
-    return decodeHtmlEntities(data.responseData.translatedText);
+  const translated = data.responseData?.translatedText;
+
+  if (translated) {
+    // Check if the API returned an internal error message inside the translatedText string
+    if (
+      translated.includes('QUERY LENGTH LIMIT EXCEEDED') ||
+      data.responseStatus === 403 ||
+      data.responseStatus === 429
+    ) {
+      throw new Error(data.responseDetails || 'Limite de caracteres ou cota excedidos no MyMemory.');
+    }
+    return decodeHtmlEntities(translated);
   }
   
   throw new Error(data.responseDetails || 'Erro desconhecido na tradução.');


### PR DESCRIPTION
Fatia os paragrafos de texto com mais de 400 caracteres em sentencas menores e traduz cada uma individualmente, respeitando o limite da API gratuita do MyMemory.